### PR TITLE
hotfix: stylelint 설정에 all 속성 추가 및 SCSS 순서 수정 / DP-26

### DIFF
--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -12,6 +12,11 @@
     "order/properties-order": [
       [
         {
+          "groupName": "Reset & Initial",
+          "properties": ["all", "content", "quotes"],
+          "emptyLineBefore": "never"
+        },
+        {
           "groupName": "Layout",
           "properties": [
             "position",
@@ -19,19 +24,41 @@
             "right",
             "bottom",
             "left",
+            "z-index",
             "display",
             "flex",
             "flex-direction",
             "flex-wrap",
             "flex-grow",
+            "flex-shrink",
+            "flex-basis",
             "align-items",
-            "justify-content"
+            "align-self",
+            "justify-content",
+            "justify-items",
+            "justify-self",
+            "align-content",
+            "order",
+            "grid",
+            "grid-template",
+            "grid-template-rows",
+            "grid-template-columns",
+            "grid-template-areas",
+            "grid-area",
+            "grid-row",
+            "grid-column",
+            "grid-gap",
+            "gap",
+            "float",
+            "clear",
+            "vertical-align"
           ],
           "emptyLineBefore": "never"
         },
         {
           "groupName": "Box Model",
           "properties": [
+            "box-sizing",
             "width",
             "max-width",
             "min-width",
@@ -52,21 +79,45 @@
             "border-width",
             "border-style",
             "border-color",
-            "box-sizing"
+            "border-top",
+            "border-right",
+            "border-bottom",
+            "border-left",
+            "border-radius",
+            "overflow",
+            "overflow-x",
+            "overflow-y",
+            "overflow-wrap",
+            "outline",
+            "outline-width",
+            "outline-style",
+            "outline-color",
+            "outline-offset"
           ],
           "emptyLineBefore": "never"
         },
         {
           "groupName": "Typography",
           "properties": [
+            "font",
             "font-family",
             "font-size",
             "font-weight",
+            "font-style",
+            "font-variant",
+            "font-stretch",
             "line-height",
             "letter-spacing",
-            "color",
+            "word-spacing",
             "text-align",
-            "text-decoration"
+            "text-decoration",
+            "text-transform",
+            "text-indent",
+            "text-overflow",
+            "white-space",
+            "word-break",
+            "word-wrap",
+            "color"
           ],
           "emptyLineBefore": "never"
         },
@@ -78,13 +129,17 @@
             "background-image",
             "background-size",
             "background-repeat",
-            "opacity",
+            "background-position",
+            "background-attachment",
+            "background-clip",
+            "background-origin",
             "box-shadow",
-            "border-radius"
+            "opacity",
+            "filter",
+            "backdrop-filter"
           ],
           "emptyLineBefore": "never"
         },
-
         {
           "groupName": "Animation & Transition",
           "properties": [
@@ -101,7 +156,13 @@
             "animation-iteration-count",
             "animation-direction",
             "animation-fill-mode",
-            "animation-play-state"
+            "animation-play-state",
+            "transform",
+            "transform-origin",
+            "transform-style",
+            "backface-visibility",
+            "perspective",
+            "perspective-origin"
           ],
           "emptyLineBefore": "never"
         },
@@ -110,15 +171,21 @@
           "properties": [
             "cursor",
             "pointer-events",
-            "visibility",
             "user-select",
-            "opacity",
-            "z-index",
-            "filter",
-            "backface-visibility",
-            "transform",
-            "transform-origin",
-            "will-change"
+            "user-zoom",
+            "visibility",
+            "will-change",
+            "resize",
+            "appearance",
+            "list-style",
+            "list-style-type",
+            "list-style-position",
+            "list-style-image",
+            "table-layout",
+            "border-collapse",
+            "border-spacing",
+            "empty-cells",
+            "caption-side"
           ],
           "emptyLineBefore": "never"
         }

--- a/src/components/atoms/Button/Button.scss
+++ b/src/components/atoms/Button/Button.scss
@@ -6,13 +6,13 @@
   justify-content: center;
   padding: 13px 24px;
   border: none;
+  border-radius: 10px;
   font-family: vars.$font-family-inter;
   font-size: vars.$font-size-xsmall;
   font-weight: vars.$font-weight-bold;
   line-height: vars.$default-line-height;
-  border-radius: 10px;
-  transition: all 0.2s ease-in-out;
   white-space: nowrap;
+  transition: all 0.2s ease-in-out;
 
   &:focus {
     outline: none;

--- a/src/components/atoms/Input/Input.scss
+++ b/src/components/atoms/Input/Input.scss
@@ -41,12 +41,12 @@
   width: 100%;
   padding: 14px 12px;
   border: 1px solid vars.$gray-7;
+  border-radius: 10px;
   font-family: vars.$font-family-inter;
   font-size: vars.$font-size-xsmall;
   font-weight: vars.$font-weight-medium;
   color: vars.$black-1;
   background-color: vars.$white-2;
-  border-radius: 10px;
   transition: all 0.2s ease-in-out;
 
   &::placeholder {
@@ -56,8 +56,8 @@
 
   &:focus {
     border-color: vars.$blue-3;
-    box-shadow: 0 0 0 1px vars.$blue-3;
     outline: none;
+    box-shadow: 0 0 0 1px vars.$blue-3;
   }
 
   &--error {

--- a/src/styles/_fonts.scss
+++ b/src/styles/_fonts.scss
@@ -2,16 +2,16 @@
 @font-face {
   font-family: Inter;
   font-weight: 100 900;
-  font-display: swap;
   font-style: normal;
+  font-display: swap;
   src: url('@/assets/fonts/inter/Inter-VariableFont_opsz,wght.ttf') format('truetype');
 }
 
 @font-face {
   font-family: Inter;
   font-weight: 100 900;
-  font-display: swap;
   font-style: italic;
+  font-display: swap;
   src: url('@/assets/fonts/inter/Inter-Italic-VariableFont_opsz,wght.ttf') format('truetype');
 }
 
@@ -19,15 +19,15 @@
 @font-face {
   font-family: Silkscreen;
   font-weight: 400;
-  font-display: swap;
   font-style: normal;
+  font-display: swap;
   src: url('@/assets/fonts/Silkscreen/Silkscreen-Regular.ttf') format('truetype');
 }
 
 @font-face {
   font-family: Silkscreen;
   font-weight: 700;
-  font-display: swap;
   font-style: normal;
+  font-display: swap;
   src: url('@/assets/fonts/Silkscreen/Silkscreen-Bold.ttf') format('truetype');
 }

--- a/src/styles/index.scss
+++ b/src/styles/index.scss
@@ -11,8 +11,8 @@
 // 링크 스타일링
 a {
   font-weight: 500;
-  color: #646cff;
   text-decoration: inherit;
+  color: #646cff;
 
   &:hover {
     color: #535bf2;
@@ -30,6 +30,6 @@ body {
 // 버튼 스타일링
 button {
   border: none;
-  cursor: pointer;
   outline: none;
+  cursor: pointer;
 }


### PR DESCRIPTION
## 🔀 PR 제목
- [Hotfix] stylelint 설정에 all 속성 추가 및 CSS 순서 수정

---

## 📌 작업 내용 요약
토글 스타일링에서 발생한 CSS 속성 순서 문제를 해결했습니다.

- stylelint 설정에 "Reset & Initial" 그룹 추가하여 all 속성을 최상단으로 배치
- all, content, quotes 등 순서가 중요한 속성들을 최우선 그룹으로 설정
- Layout, Box Model, Typography 등 기존 그룹에 누락된 SCSS 속성들 추가
- box-sizing, z-index, overflow 등 중요 속성들의 위치 재정렬

---

## ✅ 체크리스트
PR을 올리기 전에 아래 항목을 확인했나요?

- [x] 기능 요구사항을 모두 구현했나요?
- [x] 로컬에서 기능을 직접 테스트했나요?
- [x] 코드 컨벤션 및 스타일을 지켰나요?
- [x] 관련된 이슈에 연결했나요?

---

## 🔗 관련 이슈
- Closes #27 
