### PR TITLE
[Fix] 커밋 메세지 설정 및 테스트 진행

### DIFF
--- a/.husky/prepare-commit-msg
+++ b/.husky/prepare-commit-msg
@@ -4,15 +4,20 @@
 # 브랜치명에서 DP-숫자 패턴 확인
 branch=$(git rev-parse --abbrev-ref HEAD)
 if echo "$branch" | grep -q "DP-[0-9]\+"; then
-  # Platform detection and execution
   case "$(uname -s)" in
     CYGWIN*|MINGW*|MSYS*)
       # Windows
-      npx jira-prepare-commit-msg $1
+      npx --yes jira-prepare-commit-msg $1
       ;;
     *)
       # macOS/Linux
-      exec < /dev/tty && npx jira-prepare-commit-msg $1
+      # TTY 사용 가능한지 확인하고, 가능하면 사용
+      if [ -t 0 ] && [ -c /dev/tty ]; then
+        exec < /dev/tty && npx --yes jira-prepare-commit-msg $1
+      else
+        # TTY 사용 불가능한 환경에서는 직접 실행
+        npx --yes jira-prepare-commit-msg $1
+      fi
       ;;
   esac
 fi


### PR DESCRIPTION


## 📌 작업 내용 요약
어떤 작업을 했는지 간략히 설명해주세요.

건님께서 작업 해주신 지라 번호 자동 추가 기능을 mac에 맞게 변경하였습니다.
mac 여러분께서는 아래 명시해둔 작업을 꼭 한번씩 실행해주세요.

---
## macOS에서 Husky prepare-commit-msg 훅 권한 문제 해결 절차

```
# 1. 패키지 설치
pnpm install

# 2. husky 재설치
pnpm husky install

# 3. 실행 권한 확인
ls .husky/prepare-commit-msg
ls -l .husky/prepare-commit-msg
```
실행 권한이 없다고 나온다면 아래처럼 보입니다.
```
-rw-r--r--@ 1 parksohyun(제이름이니 신경쓰지마쇼)  staff  706  7 19 03:31 .husky/prepare-commit-msg
```

실행 권한 부여 밑 재확인
```
1.  실행 권한 부여
chmod +x .husky/prepare-commit-msg

2.  다시 확인
ls -l .husky/prepare-commit-msg

3. 결과(이게 정상)
-rwxr-xr-x  1 parksohyun  staff  ...

```

잘 나온다면 밑에 한번더 해줘요
```
pnpm husky install
```

그러고 이제 테스트 삼아 커밋 메세지 작성해보시면 됩니다~
브랜치 명에는 DP-작성 잊지 말기~

---

