### PR TITLE
Fix/dp 44 fe fix jira 번호 자동 추출 및 커밋 메시지에 자동 적용 기능 수정

### DIFF
--- a/.husky/prepare-commit-msg
+++ b/.husky/prepare-commit-msg
@@ -24,8 +24,8 @@ if echo "$BRANCH_NAME" | grep -q "DP-[0-9]\+"; then
   TITLE=$(echo "$COMMIT_MESSAGE" | head -n 1)
   BODY=$(echo "$COMMIT_MESSAGE" | tail -n +2)
   
-  # 제목에 JIRA 번호 추가
-  NEW_TITLE="$TITLE / $JIRA_TICKET"
+  # 제목 앞에 JIRA 번호 추가
+  NEW_TITLE="$JIRA_TICKET $TITLE"
   
   # 본문이 있으면 제목과 본문을 합치고, 없으면 제목만
   if [ -n "$BODY" ] && [ "$BODY" != "$TITLE" ]; then

--- a/.husky/prepare-commit-msg
+++ b/.husky/prepare-commit-msg
@@ -20,6 +20,18 @@ if echo "$BRANCH_NAME" | grep -q "DP-[0-9]\+"; then
   # 기존 커밋 메시지 읽기
   COMMIT_MESSAGE=$(cat "$COMMIT_MESSAGE_FILE_PATH")
   
-  # 커밋 메시지 뒤에 " / DP-숫자" 형식으로 추가
-  echo "$COMMIT_MESSAGE / $JIRA_TICKET" > "$COMMIT_MESSAGE_FILE_PATH"
+  # 첫 번째 줄(제목)과 나머지(본문) 분리
+  TITLE=$(echo "$COMMIT_MESSAGE" | head -n 1)
+  BODY=$(echo "$COMMIT_MESSAGE" | tail -n +2)
+  
+  # 제목에 JIRA 번호 추가
+  NEW_TITLE="$TITLE / $JIRA_TICKET"
+  
+  # 본문이 있으면 제목과 본문을 합치고, 없으면 제목만
+  if [ -n "$BODY" ] && [ "$BODY" != "$TITLE" ]; then
+    echo "$NEW_TITLE
+$BODY" > "$COMMIT_MESSAGE_FILE_PATH"
+  else
+    echo "$NEW_TITLE" > "$COMMIT_MESSAGE_FILE_PATH"
+  fi
 fi

--- a/.husky/prepare-commit-msg
+++ b/.husky/prepare-commit-msg
@@ -24,8 +24,8 @@ if echo "$BRANCH_NAME" | grep -q "DP-[0-9]\+"; then
   TITLE=$(echo "$COMMIT_MESSAGE" | head -n 1)
   BODY=$(echo "$COMMIT_MESSAGE" | tail -n +2)
   
-  # 제목 앞에 JIRA 번호 추가
-  NEW_TITLE="$JIRA_TICKET $TITLE"
+  # 제목에 JIRA 번호 추가
+  NEW_TITLE="$TITLE / $JIRA_TICKET"
   
   # 본문이 있으면 제목과 본문을 합치고, 없으면 제목만
   if [ -n "$BODY" ] && [ "$BODY" != "$TITLE" ]; then

--- a/.husky/prepare-commit-msg
+++ b/.husky/prepare-commit-msg
@@ -1,23 +1,25 @@
-#!/usr/bin/env sh
+#!/bin/sh
 . "$(dirname -- "$0")/_/husky.sh"
 
-# 브랜치명에서 DP-숫자 패턴 확인
-branch=$(git rev-parse --abbrev-ref HEAD)
-if echo "$branch" | grep -q "DP-[0-9]\+"; then
-  case "$(uname -s)" in
-    CYGWIN*|MINGW*|MSYS*)
-      # Windows
-      npx --yes jira-prepare-commit-msg $1
-      ;;
-    *)
-      # macOS/Linux
-      # TTY 사용 가능한지 확인하고, 가능하면 사용
-      if [ -t 0 ] && [ -c /dev/tty ]; then
-        exec < /dev/tty && npx --yes jira-prepare-commit-msg $1
-      else
-        # TTY 사용 불가능한 환경에서는 직접 실행
-        npx --yes jira-prepare-commit-msg $1
-      fi
-      ;;
-  esac
+# 커밋 메시지 파일 경로
+COMMIT_MESSAGE_FILE_PATH=$1
+
+# 파일 존재 확인
+if [ ! -f "$COMMIT_MESSAGE_FILE_PATH" ]; then
+  exit 0
+fi
+
+# 현재 브랜치명 가져오기
+BRANCH_NAME=$(git symbolic-ref --short HEAD 2>/dev/null || echo "")
+
+# 브랜치명에서 DP-숫자 패턴 추출
+if echo "$BRANCH_NAME" | grep -q "DP-[0-9]\+"; then
+  # DP-숫자 패턴 추출
+  JIRA_TICKET=$(echo "$BRANCH_NAME" | grep -o "DP-[0-9]\+" | head -1)
+  
+  # 기존 커밋 메시지 읽기
+  COMMIT_MESSAGE=$(cat "$COMMIT_MESSAGE_FILE_PATH")
+  
+  # 커밋 메시지 뒤에 " / DP-숫자" 형식으로 추가
+  echo "$COMMIT_MESSAGE / $JIRA_TICKET" > "$COMMIT_MESSAGE_FILE_PATH"
 fi

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,89 @@
+# Dependencies
+node_modules/
+.pnp
+.pnp.js
+
+# Build outputs
+dist/
+build/
+out/
+.next/
+.nuxt/
+
+# Cache directories
+.cache/
+.parcel-cache/
+.swc/
+
+# Environment files
+.env
+.env.local
+.env.development.local
+.env.test.local
+.env.production.local
+
+# Logs
+*.log
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+pnpm-debug.log*
+
+# Generated files
+coverage/
+.nyc_output/
+lib-cov/
+
+# Package manager files
+package-lock.json
+yarn.lock
+pnpm-lock.yaml
+
+# IDE/Editor files
+.vscode/
+.idea/
+
+# OS files
+.DS_Store
+Thumbs.db
+
+# Public assets (이미지, 폰트 등)
+public/
+static/
+
+# Documentation that shouldn't be formatted
+CHANGELOG.md
+LICENSE
+
+# Generated API docs
+docs/api/
+
+# Storybook build
+storybook-static/
+
+# CI/CD and automation files
+.github/
+README.md
+.husky/
+.gitlab-ci.yml
+.travis.yml
+.circleci/
+
+# Docker files
+Dockerfile*
+docker-compose*.yml
+.dockerignore
+
+# Configuration files that shouldn't be formatted
+.eslintrc*
+.prettierrc*
+.stylelintrc*
+tsconfig*.json
+jsconfig*.json
+babel.config.*
+webpack.config.*
+vite.config.*
+rollup.config.*
+jest.config.*
+tailwind.config.*
+postcss.config.*

--- a/.prettierrc
+++ b/.prettierrc
@@ -4,5 +4,6 @@
   "tabWidth": 2,
   "printWidth": 100,
   "trailingComma": "es5",
-  "arrowParens": "avoid"
+  "arrowParens": "avoid",
+   "endOfLine": "lf"
 }

--- a/cspell.json
+++ b/cspell.json
@@ -19,7 +19,8 @@
     "**/*.scss",
     "vite.config.ts",
     ".env",
-    ".env.example"
+    ".env.example",
+    ".prettierignore"
   ],
   "words": ["eslint", "stylelint", "prettierrc", "pnpm", "vite", "zustand", "tanstack", "Avenir"]
 }

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,9 +1,9 @@
-import js from '@eslint/js'
-import globals from 'globals'
-import reactHooks from 'eslint-plugin-react-hooks'
-import reactRefresh from 'eslint-plugin-react-refresh'
-import tseslint from 'typescript-eslint'
-import { globalIgnores } from 'eslint/config'
+import js from '@eslint/js';
+import globals from 'globals';
+import reactHooks from 'eslint-plugin-react-hooks';
+import reactRefresh from 'eslint-plugin-react-refresh';
+import tseslint from 'typescript-eslint';
+import { globalIgnores } from 'eslint/config';
 
 export default tseslint.config([
   globalIgnores(['dist']),
@@ -20,4 +20,4 @@ export default tseslint.config([
       globals: globals.browser,
     },
   },
-])
+]);

--- a/package.json
+++ b/package.json
@@ -6,7 +6,10 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc -b && vite build",
-    "lint": "eslint . --ext .js,.jsx,.ts,.tsx --fix && stylelint \"src/**/*.{css,scss}\" --fix",
+    "lint": "eslint . --ext .js,.jsx,.ts,.tsx --fix && stylelint \"src/**/*.{css,scss}\" --fix && prettier --write \"**/*.{js,jsx,ts,tsx,css,scss,json,md,yml,yaml}\"",
+    "lint:js": "eslint . --ext .js,.jsx,.ts,.tsx --fix",
+    "lint:css": "stylelint \"src/**/*.{css,scss}\" --fix",
+    "lint:format": "prettier --write \"**/*.{js,jsx,ts,tsx,css,scss,json,md,yml,yaml}\"",
     "preview": "vite preview",
     "prepare": "husky install",
     "test": "echo \"No tests yet!\""
@@ -83,10 +86,6 @@
     "*.{json,md,yml,yaml}": [
       "prettier --write"
     ]
-  },
-  "jira-prepare-commit-msg": {
-    "messagePattern": "$M / $J",
-    "jiraTicketPattern": "(DP-\\d+)"
   },
   "packageManager": "pnpm@10.12.1+sha512.f0dda8580f0ee9481c5c79a1d927b9164f2c478e90992ad268bbb2465a736984391d6333d2c327913578b2804af33474ca554ba29c04a8b13060a717675ae3ac"
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -140,9 +140,6 @@ importers:
       husky:
         specifier: ^8.0.0
         version: 8.0.3
-      jira-prepare-commit-msg:
-        specifier: ^1.7.2
-        version: 1.7.2(typescript@5.8.3)
       lint-staged:
         specifier: ^16.1.2
         version: 16.1.2
@@ -3666,14 +3663,6 @@ packages:
         integrity: sha512-H0dkQoCa3b2VEeKQBOxFph+JAbcrQdE7KC0UkqwpLmv2EC4P41QXP+rqo9wYodACiG5/WM5s9oDApTU8utwj9g==,
       }
     engines: { node: '>= 0.4' }
-
-  jira-prepare-commit-msg@1.7.2:
-    resolution:
-      {
-        integrity: sha512-vPmwqPoi5TfMF1rXh9XN6u7TiSG+FwdcbeL01nMBUbRRxTMXvIqQZoJSRoNoprgY1JUpYXplc3HGRSVsV22rLg==,
-      }
-    engines: { node: '>=14' }
-    hasBin: true
 
   js-tokens@4.0.0:
     resolution:
@@ -7486,12 +7475,6 @@ snapshots:
       get-proto: 1.0.1
       has-symbols: 1.1.0
       set-function-name: 2.0.2
-
-  jira-prepare-commit-msg@1.7.2(typescript@5.8.3):
-    dependencies:
-      cosmiconfig: 8.3.6(typescript@5.8.3)
-    transitivePeerDependencies:
-      - typescript
 
   js-tokens@4.0.0: {}
 

--- a/src/components/Header/variants/HeaderVariant.module.scss
+++ b/src/components/Header/variants/HeaderVariant.module.scss
@@ -7,12 +7,12 @@
 .profileButton {
   display: flex;
   align-items: center;
+  gap: 0.5rem;
   border: none;
   font-weight: $font-weight-medium;
   color: var(--header-username);
   background: none;
   cursor: pointer;
-  gap: 0.5rem;
 }
 
 .avatar {
@@ -21,6 +21,6 @@
   justify-content: center;
   width: 32px;
   height: 32px;
-  background-color: $green;
   border-radius: 50%;
+  background-color: $green;
 }

--- a/src/components/Header/variants/RepoHeader.module.scss
+++ b/src/components/Header/variants/RepoHeader.module.scss
@@ -5,10 +5,10 @@
   display: flex;
   align-items: center;
   justify-content: flex-end;
+  box-sizing: border-box;
   width: 100%;
   height: 56px;
   padding: 0 1rem;
-  box-sizing: border-box;
 }
 
 .center {
@@ -16,20 +16,20 @@
   left: 50%;
   display: flex;
   align-items: center;
-  transform: translateX(-50%);
   gap: 1rem;
   white-space: nowrap;
+  transform: translateX(-50%);
 }
 
 .pathArea {
   display: flex;
   align-items: center;
+  gap: 0.5rem;
   padding: 0.5rem 6rem;
+  border-radius: 8px;
   font-size: $font-size-xsmall;
   color: var(--header-text);
   background-color: var(--header-path-bg);
-  border-radius: 8px;
-  gap: 0.5rem;
 }
 
 .icon {
@@ -44,11 +44,11 @@
   justify-content: center;
   width: 29px;
   height: 29px;
+  border-radius: 5px;
   color: var(--header-chat-icon);
   background: none;
   background-color: var(--header-chat-bg);
   box-shadow: $shadow;
-  border-radius: 5px;
   cursor: pointer;
 }
 

--- a/src/components/Sidebar/MainSidebar/MainSidebar.module.scss
+++ b/src/components/Sidebar/MainSidebar/MainSidebar.module.scss
@@ -25,9 +25,9 @@
   height: 29px;
   padding: 0;
   border: 1px solid vars.$gray-8;
+  border-radius: 5px;
   color: vars.$black-1;
   background-color: vars.$white-2;
-  border-radius: 5px;
   cursor: pointer;
 
   &:hover {
@@ -36,8 +36,8 @@
   }
 
   .iconImage {
+    flex-shrink: 0;
     width: 20px;
     height: 20px;
-    flex-shrink: 0;
   }
 }

--- a/src/components/Sidebar/RepoSidebar/RepoSidebar.module.scss
+++ b/src/components/Sidebar/RepoSidebar/RepoSidebar.module.scss
@@ -29,9 +29,9 @@
   width: 29px;
   height: 29px;
   padding: 0;
+  border-radius: 5px;
   color: vars.$gray-5;
   background-color: vars.$white-2;
-  border-radius: 5px;
   cursor: pointer;
 
   [data-theme='dark'] & {
@@ -50,8 +50,8 @@
   }
 
   .iconImage {
+    flex-shrink: 0;
     width: 20px;
     height: 20px;
-    flex-shrink: 0;
   }
 }

--- a/src/components/atoms/Toggle/Toggle.module.scss
+++ b/src/components/atoms/Toggle/Toggle.module.scss
@@ -2,15 +2,15 @@
 
 .root {
   position: relative;
+  box-sizing: border-box;
   width: 67px;
   height: 30px;
   border: 2px solid $gray-7;
-  box-sizing: border-box;
+  border-radius: 9999px;
   background-color: $gray-8;
   background-repeat: no-repeat;
-  border-radius: 9999px;
-  transition: background-color 0.2s ease;
   background-position: center right 6px;
+  transition: background-color 0.2s ease;
 }
 
 .thumb {
@@ -20,8 +20,8 @@
   display: block;
   width: 24px;
   height: 24px;
-  background-color: $white-2;
   border-radius: 50%;
+  background-color: $white-2;
   transition: transform 0.2s ease;
   transform: translateY(-50%);
 }

--- a/src/components/atoms/Tooltip/Tooltip.module.scss
+++ b/src/components/atoms/Tooltip/Tooltip.module.scss
@@ -2,14 +2,14 @@
 
 .tooltip {
   padding: 6px 10px;
+  border-radius: 5px;
   font-family: vars.$font-family-inter;
   font-size: vars.$font-size-xxsmall;
   font-weight: vars.$font-weight-semi-bold;
+  white-space: nowrap;
   color: vars.$black-1;
   background-color: vars.$white-2;
   box-shadow: 0 2px 10px rgb(0 0 0 / 8%);
-  border-radius: 5px;
-  white-space: nowrap;
 }
 
 .arrow {


### PR DESCRIPTION
## 🔀 PR 제목
Fix/DP 44 fe fix jira 번호 자동 추출 및 커밋 메시지에 자동 적용 기능 수정

---

## 📌 작업 내용 요약
- 인텔리제이 환경에서는 "jira-prepare-commit-msg"를 사용할 수 없어, commit 메시지에 Jira 번호를 자동으로 추가해주지 않는 문제 해결
  - "jira-prepare-commit-msg"를 사용하는 것이 아닌 직접 husky의 prepare-commit-msg에 내용을 작성하여 모든 환경에서 사용할 수 있도록 함.
- Window와 macOS의 줄바꿈 처리 방식 차이로 인한 문제를 해결
- prettier 동작을 package.json 스크립트에 추가
---

## ✅ 체크리스트
PR을 올리기 전에 아래 항목을 확인했나요?

- [x] 기능 요구사항을 모두 구현했나요?
- [x] 로컬에서 기능을 직접 테스트했나요?
- [x] 코드 컨벤션 및 스타일을 지켰나요?
- [x] 관련된 이슈에 연결했나요?

---

## 🔗 관련 이슈
- Closes #45 

## 📎 기타 참고 사항
- VSCode, macOS, Window, IntelliJ 에서 모두 잘 동작하는 것을 확인했습니다.
- "jira-prepare-commit-msg" 패키지를 삭제하였으니, 본 PR 병합 이후 사용하시는 모든 분들은 pnpm install을 다시 한번 진행해주시면 감사하겠습니다.
- Window와 macOS의 줄바꿈 처리 방식 차이로 인한 문제를 해결하였습니다.
- prettier 동작을 package.json 스크립트에 추가해놓았습니다.
