### PR TITLE
Dp 35 fe feature 아이디 찾기 페이지 UI 제작

### DIFF
--- a/src/pages/FindIdPage/FIndIdPage.module.scss
+++ b/src/pages/FindIdPage/FIndIdPage.module.scss
@@ -81,3 +81,12 @@
     white-space: nowrap;
   }
 }
+
+.error {
+  margin-top: 0.2rem;
+  margin-left: 0.5rem;
+  font-size: $font-size-xxsmall;
+  font-weight: $font-weight-bold;
+  text-align: left;
+  color: $orange;
+}

--- a/src/pages/FindIdPage/FIndIdPage.module.scss
+++ b/src/pages/FindIdPage/FIndIdPage.module.scss
@@ -1,0 +1,83 @@
+@use '@/styles/variables.scss' as *;
+
+.inner {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  width: 100%;
+  max-width: 500px;
+  margin: auto;
+}
+
+.form {
+  width: 100%;
+}
+
+.title {
+  margin-top: 1rem;
+  font-size: $font-size-xxxlarge;
+  font-weight: $font-weight-bold;
+  color: $blue-3;
+}
+
+.text {
+  margin-bottom: 2rem;
+  font-size: $font-size-xsmall;
+  font-weight: $font-weight-bold;
+  color: $gray-6;
+}
+
+.options {
+  margin-bottom: 0.5rem;
+  font-size: $font-size-xsmall;
+}
+
+.submitBtn {
+  width: 100%;
+  margin-bottom: 1rem;
+}
+
+.links {
+  display: flex;
+  justify-content: space-between;
+  width: 100%;
+}
+
+.link {
+  font-size: $font-size-xxsmall;
+  font-weight: $font-weight-bold;
+  text-decoration: none;
+  color: $gray-1;
+  cursor: pointer;
+
+  &:hover {
+    text-decoration: underline;
+    color: $gray-1;
+  }
+}
+
+.linkWarning {
+  text-decoration: none;
+  color: $orange;
+  cursor: pointer;
+
+  &:hover {
+    text-decoration: underline;
+    color: $orange;
+  }
+}
+
+.fieldWithButton {
+  display: flex;
+  gap: 0.5rem;
+  width: 100%;
+
+  input {
+    flex: 1;
+  }
+
+  button {
+    width: 10.6rem;
+    white-space: nowrap;
+  }
+}

--- a/src/pages/FindIdPage/FindIdCompletePage.module.scss
+++ b/src/pages/FindIdPage/FindIdCompletePage.module.scss
@@ -10,7 +10,6 @@
 }
 
 .title {
-  margin-top: 1rem;
   margin-bottom: 2.5rem;
   font-size: $font-size-xxxlarge;
   font-weight: $font-weight-bold;
@@ -20,7 +19,7 @@
 
 .email {
   width: 100%;
-  margin-bottom: 2.5rem;
+  margin-bottom: 3rem;
   font-size: $font-size-xsmall;
   font-weight: $font-weight-bold;
   text-align: center;
@@ -31,5 +30,4 @@
 
 .submitBtn {
   width: 100%;
-  margin-bottom: 1rem;
 }

--- a/src/pages/FindIdPage/FindIdCompletePage.module.scss
+++ b/src/pages/FindIdPage/FindIdCompletePage.module.scss
@@ -1,0 +1,35 @@
+@use '@/styles/variables.scss' as *;
+
+.inner {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  width: 100%;
+  max-width: 500px;
+  margin: auto;
+}
+
+.title {
+  margin-top: 1rem;
+  margin-bottom: 2.5rem;
+  font-size: $font-size-xxxlarge;
+  font-weight: $font-weight-bold;
+  text-align: left;
+  color: $blue-3;
+}
+
+.email {
+  width: 100%;
+  margin-bottom: 2.5rem;
+  font-size: $font-size-xsmall;
+  font-weight: $font-weight-bold;
+  text-align: center;
+  text-decoration: underline;
+  word-break: break-all;
+  color: $gray-2;
+}
+
+.submitBtn {
+  width: 100%;
+  margin-bottom: 1rem;
+}

--- a/src/pages/FindIdPage/FindIdCompletePage.tsx
+++ b/src/pages/FindIdPage/FindIdCompletePage.tsx
@@ -1,0 +1,27 @@
+import { Link, useSearch } from '@tanstack/react-router';
+import { findIdCompleteRoute } from '@/router/routes/auth/find-id-complete';
+import styles from './FindIdCompletePage.module.scss';
+import Button from '@/components/atoms/Button/Button';
+
+export default function FindIdCompletePage() {
+  const { email } = useSearch({ from: findIdCompleteRoute.id });
+
+  return (
+    <div className={styles.inner}>
+      <h1 className={styles.title}>당신의 이메일은!</h1>
+      <div className={styles.email}>
+        <span>{email}</span>
+      </div>
+      <Link to="/sign-in" style={{ width: '100%' }}>
+        <Button
+          className={styles.submitBtn}
+          variant="active"
+          type="button"
+          style={{ width: '100%' }}
+        >
+          로그인으로
+        </Button>
+      </Link>
+    </div>
+  );
+}

--- a/src/pages/FindIdPage/FindIdForm.tsx
+++ b/src/pages/FindIdPage/FindIdForm.tsx
@@ -60,7 +60,7 @@ export default function FindIdForm() {
       data.phoneNumber === '01012345678' &&
       data.phoneCode === '123456'
     ) {
-      //완료페이지로 email 전달하며 이동!
+      // 완료페이지로 email 전달하며 이동!
       navigate({
         to: '/find-id/complete',
         search: { email: 'goorm@email.com' },

--- a/src/pages/FindIdPage/FindIdForm.tsx
+++ b/src/pages/FindIdPage/FindIdForm.tsx
@@ -1,0 +1,126 @@
+import { useState } from 'react';
+import { useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { findIdSchema, type FindIdFormValues } from '@/schemas/auth.schema';
+import Input from '@/components/atoms/Input/Input';
+import Button from '@/components/atoms/Button/Button';
+import FormField from '@/components/molecules/FormField';
+import { useNavigate } from '@tanstack/react-router';
+import styles from './FindIdPage.module.scss';
+
+export default function FindIdForm() {
+  const {
+    register,
+    handleSubmit,
+    watch,
+    formState: { errors, isSubmitting },
+  } = useForm<FindIdFormValues>({
+    resolver: zodResolver(findIdSchema),
+    mode: 'onChange',
+  });
+
+  const [codeSent, setCodeSent] = useState(false);
+  const [codeVerified, setCodeVerified] = useState(false);
+  const [timer, setTimer] = useState(0);
+  const [foundEmail, setFoundEmail] = useState<string | null>(null);
+
+  const navigate = useNavigate();
+
+  const phone = watch('phoneNumber');
+  const phoneCode = watch('phoneCode');
+
+  const startTimer = () => {
+    setTimer(59);
+    const interval = setInterval(() => {
+      setTimer(prev => {
+        if (prev <= 1) {
+          clearInterval(interval);
+          return 0;
+        }
+        return prev - 1;
+      });
+    }, 1000);
+  };
+
+  const handleSendCode = () => {
+    setCodeSent(true);
+    startTimer();
+    // TODO: 실제 API 연동
+  };
+
+  const handleVerifyCode = () => {
+    setCodeVerified(true);
+    // TODO: 실제 API 연동
+  };
+
+  const onSubmit = (data: FindIdFormValues) => {
+    // TODO: 실제로 백엔드와 연동
+    if (
+      data.username === '구름' &&
+      data.phoneNumber === '01012345678' &&
+      data.phoneCode === '123456'
+    ) {
+      //완료페이지로 email 전달하며 이동!
+      navigate({
+        to: '/find-id/complete',
+        search: { email: 'goorm@email.com' },
+      });
+    } else {
+      setFoundEmail('');
+    }
+  };
+
+  return (
+    <form onSubmit={handleSubmit(onSubmit)} className={styles.form}>
+      <FormField label="이름" htmlFor="username" required error={errors.username?.message}>
+        <Input id="username" {...register('username')} placeholder="구름" />
+      </FormField>
+
+      <FormField
+        label="휴대폰 번호"
+        htmlFor="phoneNumber"
+        required
+        error={errors.phoneNumber?.message}
+      >
+        <div className={styles.fieldWithButton}>
+          <Input id="phoneNumber" {...register('phoneNumber')} placeholder="01012345678" />
+          <Button
+            type="button"
+            onClick={handleSendCode}
+            disabled={!phone || timer > 0}
+            variant={codeSent ? 'inactive' : 'active'}
+          >
+            {timer > 0 ? `0:${timer}` : '인증번호 발송'}
+          </Button>
+        </div>
+      </FormField>
+
+      <FormField label="인증번호" htmlFor="phoneCode" required error={errors.phoneCode?.message}>
+        <div className={styles.fieldWithButton}>
+          <Input id="phoneCode" {...register('phoneCode')} placeholder="123456" />
+          <Button
+            type="button"
+            onClick={handleVerifyCode}
+            disabled={!phoneCode || codeVerified}
+            variant={codeVerified ? 'inactive' : 'active'}
+          >
+            {codeVerified ? '인증 완료' : '인증하기'}
+          </Button>
+        </div>
+      </FormField>
+
+      <Button
+        type="submit"
+        className={styles.submitBtn}
+        disabled={isSubmitting || !codeVerified}
+        variant={codeVerified ? 'active' : 'general'}
+      >
+        이메일 찾기
+      </Button>
+
+      {foundEmail === '' && (
+        <div className={styles.error}>입력하신 정보로 가입된 이메일을 찾을 수 없습니다.</div>
+      )}
+    </form>
+  );
+}

--- a/src/pages/FindIdPage/FindIdPage.tsx
+++ b/src/pages/FindIdPage/FindIdPage.tsx
@@ -1,0 +1,22 @@
+import FindIdForm from './FindIdForm';
+import { Link } from '@tanstack/react-router';
+import styles from './FindIdPage.module.scss';
+
+export default function FindIdPage() {
+  return (
+    <div className={styles.inner}>
+      <h1 className={styles.title}>이메일을 잊어버리셨습니까?</h1>
+      <p className={styles.text}>가입한 이름과 전화번호 정보를 입력하고, 이메일을 찾아가세요!</p>
+      <FindIdForm />
+
+      <div className={styles.links}>
+        <Link to="/" className={styles.link}>
+          비밀번호가 기억이 나지 않습니다..
+        </Link>
+        <Link to="/sign-in" className={`${styles.link} ${styles.linkWarning}`}>
+          <span>아이디가 기억 나는거 같아요!</span>
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/src/pages/SignInPage/SignInPage.tsx
+++ b/src/pages/SignInPage/SignInPage.tsx
@@ -11,7 +11,7 @@ export default function SignInPage() {
       <SignInForm />
 
       <div className={styles.links}>
-        <Link to="/" className={styles.link}>
+        <Link to="/find-id" className={styles.link}>
           아이디/비밀번호를 잊어버렸습니다..
         </Link>
         <Link to="/sign-up" className={`${styles.link} ${styles.linkWarning}`}>

--- a/src/router/routeTree.ts
+++ b/src/router/routeTree.ts
@@ -2,10 +2,11 @@ import { rootRoute } from './root';
 import { authLayoutRoute } from './routes/auth/auth-layout';
 import { signInRoute } from './routes/auth/sign-in';
 import { signUpRoute } from './routes/auth/sign-up';
+import { findIdRoute } from './routes/auth/find-id';
 import { mainLayoutRoute } from './routes/main/main-layout';
 import { myRepositoriesRoute } from './routes/main/my-repositories';
 
 export const routeTree = rootRoute.addChildren([
-  authLayoutRoute.addChildren([signInRoute, signUpRoute]),
+  authLayoutRoute.addChildren([signInRoute, signUpRoute, findIdRoute]),
   mainLayoutRoute.addChildren([myRepositoriesRoute]),
 ]);

--- a/src/router/routeTree.ts
+++ b/src/router/routeTree.ts
@@ -3,10 +3,11 @@ import { authLayoutRoute } from './routes/auth/auth-layout';
 import { signInRoute } from './routes/auth/sign-in';
 import { signUpRoute } from './routes/auth/sign-up';
 import { findIdRoute } from './routes/auth/find-id';
+import { findIdCompleteRoute } from './routes/auth/find-id-complete';
 import { mainLayoutRoute } from './routes/main/main-layout';
 import { myRepositoriesRoute } from './routes/main/my-repositories';
 
 export const routeTree = rootRoute.addChildren([
-  authLayoutRoute.addChildren([signInRoute, signUpRoute, findIdRoute]),
+  authLayoutRoute.addChildren([signInRoute, signUpRoute, findIdRoute, findIdCompleteRoute]),
   mainLayoutRoute.addChildren([myRepositoriesRoute]),
 ]);

--- a/src/router/routes/auth/find-id-complete.tsx
+++ b/src/router/routes/auth/find-id-complete.tsx
@@ -1,0 +1,12 @@
+import { createRoute } from '@tanstack/react-router';
+import { authLayoutRoute } from './auth-layout';
+import FindIdCompletePage from '@/pages/FindIdPage/FindIdCompletePage';
+
+export const findIdCompleteRoute = createRoute({
+  getParentRoute: () => authLayoutRoute,
+  path: 'find-id/complete',
+  component: FindIdCompletePage,
+  validateSearch: search => ({
+    email: String(search.email ?? ''),
+  }),
+});

--- a/src/router/routes/auth/find-id.tsx
+++ b/src/router/routes/auth/find-id.tsx
@@ -1,0 +1,9 @@
+import { createRoute } from '@tanstack/react-router';
+import { authLayoutRoute } from './auth-layout';
+import FindIdPage from '@/pages/FindIdPage/FindIdPage';
+
+export const findIdRoute = createRoute({
+  getParentRoute: () => authLayoutRoute,
+  path: 'find-id',
+  component: FindIdPage,
+});

--- a/src/schemas/auth.schema.ts
+++ b/src/schemas/auth.schema.ts
@@ -55,6 +55,7 @@ export const signUpSchema = z
 
 export type SignUpFormValues = z.infer<typeof signUpSchema>;
 
+// 아이디 찾기 스키마
 export const findIdSchema = z.object({
   username: z.string().nonempty('이름을 입력해주세요.').min(2, '이름은 2자 이상이어야 합니다.'),
 

--- a/src/schemas/auth.schema.ts
+++ b/src/schemas/auth.schema.ts
@@ -54,3 +54,13 @@ export const signUpSchema = z
   });
 
 export type SignUpFormValues = z.infer<typeof signUpSchema>;
+
+export const findIdSchema = z.object({
+  username: z.string().nonempty('이름을 입력해주세요.').min(2, '이름은 2자 이상이어야 합니다.'),
+
+  phoneNumber: phoneNumberSchema,
+
+  phoneCode: phoneCodeSchema,
+});
+
+export type FindIdFormValues = z.infer<typeof findIdSchema>;


### PR DESCRIPTION
## 📌 작업 내용 요약
- 아이디 찾기 페이지 제작
<img width="638" height="649" alt="스크린샷 2025-07-22 오전 4 24 03" src="https://github.com/user-attachments/assets/1c99d18a-7e48-41b9-9f14-166f4cce0178" />    
   
    - 버튼 비활성화 시 커서 또한 비활성화 표시
    - 모든 필드 입력 시 버튼 활성화 처리

<img width="638" height="649" alt="스크린샷 2025-07-22 오전 4 25 32" src="https://github.com/user-attachments/assets/dbab2d96-b3ef-4c73-a923-556e92e868bf" />      

- 아이디 찾기 성공 페이지 제작
<img width="638" height="649" alt="스크린샷 2025-07-22 오전 4 26 15" src="https://github.com/user-attachments/assets/0c02f411-8f82-4b97-9847-e06858323956" />

    - 이름 : 구름
    - 휴대폰 번호 : 01012345678
    - 인증번호 : 123456
    - 위 필드 입력시 이메일 찾기 성공 처리

- 아이디 찾기 실패 처리
<img width="638" height="649" alt="스크린샷 2025-07-22 오전 4 29 46" src="https://github.com/user-attachments/assets/f2fdb165-b5ce-45d8-bc53-fa0806b5b7d2" />

     - 피그마 상으로 아이디 찾기 실패에 관한 에러처리가 없는 것 같아서 토스트를 만들려다 통일성을 위해 에러메시지를 만들었습니다.
     - 제가 놓친게 있다면 추후 수정을 하도록 하겠습니다.

---

## ✅ 체크리스트
PR을 올리기 전에 아래 항목을 확인했나요?

- [ ] 기능 요구사항을 모두 구현했나요?
- [ ] 로컬에서 기능을 직접 테스트했나요?
- [ ] 코드 컨벤션 및 스타일을 지켰나요?
- [ ] 관련된 이슈에 연결했나요?

---

## 🔗 관련 이슈

- Closes #35 

---

## 📎 기타 참고 사항

- 로그인 페이지 "아이디/비밀번호를 잊어버렸습니다."와 연결 완료
- To.소뎅 회원가입 완료 페이지는 어딨죠..? 제가 못찾는건가요?
