### PR TITLE
[Feature] 랜딩 페이지 라우터 연결

### DIFF
--- a/src/pages/LandingPage/LandingPage.tsx
+++ b/src/pages/LandingPage/LandingPage.tsx
@@ -1,11 +1,16 @@
 import React, { useState } from 'react';
+import { useNavigate } from '@tanstack/react-router';
 import './LandingPage.scss';
 
 const LandingPage: React.FC = () => {
   const [isStarted, setIsStarted] = useState(false);
+  const navigate = useNavigate();
 
   const handleStartClick = () => {
     setIsStarted(true);
+    setTimeout(() => {
+      navigate({ to: '/sign-in' });
+    }, 1500);
   };
 
   return (

--- a/src/router/routeTree.ts
+++ b/src/router/routeTree.ts
@@ -1,4 +1,5 @@
 import { rootRoute } from './root';
+import { landingRoute } from './routes/landing/landing';
 import { authLayoutRoute } from './routes/auth/auth-layout';
 import { signInRoute } from './routes/auth/sign-in';
 import { signUpRoute } from './routes/auth/sign-up';
@@ -9,6 +10,7 @@ import { mainLayoutRoute } from './routes/main/main-layout';
 import { myRepositoriesRoute } from './routes/main/my-repositories';
 
 export const routeTree = rootRoute.addChildren([
+  landingRoute,
   authLayoutRoute.addChildren([
     signInRoute,
     signUpRoute,

--- a/src/router/routes/landing/landing.tsx
+++ b/src/router/routes/landing/landing.tsx
@@ -1,0 +1,9 @@
+import { createRoute } from '@tanstack/react-router';
+import { rootRoute } from '@/router/root';
+import LandingPage from '@/pages/LandingPage/LandingPage';
+
+export const landingRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: '/',
+  component: LandingPage,
+});


### PR DESCRIPTION
## 📌 작업 내용 요약

- 랜딩 페이지 라우터를 작성하고 홈 경로('/')에 연결했습니다.
- start 버튼을 누르면 애니메이션을 위한 1.5초 지연 후 'sign-in'으로 이동합니다.

---

## ✅ 체크리스트
PR을 올리기 전에 아래 항목을 확인했나요?

- [x] 기능 요구사항을 모두 구현했나요?
- [x] 로컬에서 기능을 직접 테스트했나요?
- [x] 코드 컨벤션 및 스타일을 지켰나요?
- [x] 관련된 이슈에 연결했나요?

---

## 🔗 관련 이슈

- Closes #63 
