### PR TITLE
Refactor/dp 109/theme change into localstorage

### DIFF
--- a/src/components/organisms/Sidebar/RepoSidebar/RepoSidebar.module.scss
+++ b/src/components/organisms/Sidebar/RepoSidebar/RepoSidebar.module.scss
@@ -10,7 +10,7 @@
   padding: 12px 0;
   background-color: vars.$gray-9;
 
-  [data-theme='dark'] & {
+  :global(.dark) & {
     background-color: vars.$black-2;
   }
 }
@@ -34,7 +34,7 @@
   background-color: vars.$white-2;
   cursor: pointer;
 
-  [data-theme='dark'] & {
+  :global(.dark) & {
     color: vars.$white-2;
     background-color: vars.$gray-5;
   }
@@ -43,7 +43,7 @@
     color: vars.$white-2;
     background-color: vars.$gray-5;
 
-    [data-theme='dark'] & {
+    :global(.dark) & {
       color: vars.$gray-5;
       background-color: vars.$white-2;
     }

--- a/src/stores/themeStore.ts
+++ b/src/stores/themeStore.ts
@@ -1,16 +1,62 @@
 import { create } from 'zustand';
+import { persist } from 'zustand/middleware';
 
 type ThemeState = {
   isDarkMode: boolean;
   toggleTheme: () => void;
+  initializeTheme: () => void;
 };
 
-export const useThemeStore = create<ThemeState>(set => ({
-  isDarkMode: false,
-  toggleTheme: () =>
-    set(state => {
-      const next = !state.isDarkMode;
-      document.documentElement.classList.toggle('dark', next);
-      return { isDarkMode: next };
+// 시스템 다크모드 감지
+const getSystemDarkMode = (): boolean => {
+  if (typeof window === 'undefined') return false;
+  return window.matchMedia('(prefers-color-scheme: dark)').matches;
+};
+
+export const useThemeStore = create<ThemeState>()(
+  persist(
+    (set, get) => ({
+      isDarkMode: false, // 기본값 (persist에서 초기화됨)
+
+      toggleTheme: () =>
+        set(state => {
+          const next = !state.isDarkMode;
+          document.documentElement.classList.toggle('dark', next);
+          return { isDarkMode: next };
+        }),
+
+      initializeTheme: () => {
+        const { isDarkMode } = get();
+        document.documentElement.classList.toggle('dark', isDarkMode);
+      },
     }),
-}));
+    {
+      name: 'theme-storage',
+      version: 1,
+
+      // 스토리지에서 값을 가져온 후 DOM에 적용
+      onRehydrateStorage: () => state => {
+        if (state) {
+          document.documentElement.classList.toggle('dark', state.isDarkMode);
+        }
+      },
+
+      // 초기화 시 로컬스토리지에 값이 없으면 시스템 테마로 설정
+      merge: (persistedState, currentState): ThemeState => {
+        // 로컬스토리지에 저장된 값이 있고 올바른 형태인지 확인
+        if (
+          persistedState &&
+          typeof persistedState === 'object' &&
+          'isDarkMode' in persistedState &&
+          typeof persistedState.isDarkMode === 'boolean'
+        ) {
+          return { ...currentState, isDarkMode: persistedState.isDarkMode };
+        }
+
+        // 로컬스토리지에 값이 없거나 유효하지 않으면 시스템 테마를 초기값으로 사용
+        const systemDarkMode = getSystemDarkMode();
+        return { ...currentState, isDarkMode: systemDarkMode };
+      },
+    }
+  )
+);


### PR DESCRIPTION
## 🔀 PR 제목
- [FE][Feature] 테마 관리 로컬스토리지 활용으로 변경
---

## 📌 작업 내용 요약
- 테마 모드를 로컬스토리지를 활용하여 적용하도록 변경함

---

## ✅ 체크리스트
PR을 올리기 전에 아래 항목을 확인했나요?

- [x] 기능 요구사항을 모두 구현했나요?
- [x] 로컬에서 기능을 직접 테스트했나요?
- [x] 코드 컨벤션 및 스타일을 지켰나요?
- [x] 관련된 이슈에 연결했나요?

---

## 🔗 관련 이슈


- Closes #85 

## 참고
- 기본적으로 초기값은 시스템 설정을 따르도록 설정하였습니다.
- 시스템 설정을 초기값으로 사용이라는 기능을 활용하고자 한다면, 추후 로그아웃이나 페이지 이동시 로컬 스토리지 삭제 등의 로직을 추가해서 관리하면 좋을 듯 합니다.
