### PR TITLE
[Feature] 채팅 글자수 세기 기능 구현

### DIFF
--- a/src/features/Chat/components/ChatInput/ChatInput.scss
+++ b/src/features/Chat/components/ChatInput/ChatInput.scss
@@ -27,9 +27,20 @@
   }
 }
 
+.chat-input__character-counter {
+  padding: 3px 20px;
+  font-size: $font-size-xxxsmall;
+  text-align: right;
+  color: $gray-6;
+
+  .dark & {
+    color: $gray-7;
+  }
+}
+
 .chat-input__input {
   flex: 1;
-  padding: 20px;
+  padding: 20px 20px 0;
   border: none;
   font-size: $font-size-xxsmall;
   font-weight: $font-weight-bold;
@@ -53,6 +64,10 @@
       color: $white-2;
     }
   }
+}
+
+.chat-input__input::-webkit-scrollbar {
+  display: none;
 }
 
 .chat-input__footer {

--- a/src/features/Chat/components/ChatInput/ChatInput.tsx
+++ b/src/features/Chat/components/ChatInput/ChatInput.tsx
@@ -7,12 +7,24 @@ interface ChatInputProps {
   helpText?: string;
 }
 
+const MAX_MESSAGE_LENGTH = 300;
+
 const ChatInput: React.FC<ChatInputProps> = ({
   onSendMessage,
   placeholder = '채팅 내용을 입력하세요',
   helpText = '코드 참조 시 #을 입력 후 해당 파일의 위치를 작성해주세요',
 }) => {
   const [message, setMessage] = useState('');
+
+  const handleMessageChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+    const input = e.target.value;
+    // 문자열의 실제 길이를 계산
+    const currentLength = [...input].length; // 스프레드 연산자를 사용하여 정확한 문자 수 계산
+
+    if (currentLength <= MAX_MESSAGE_LENGTH) {
+      setMessage(input);
+    }
+  };
 
   // TODO - 웹소켓을 통해 코드 전송하는 기능 구현 필요
 
@@ -39,10 +51,16 @@ const ChatInput: React.FC<ChatInputProps> = ({
         <textarea
           className="chat-input__input"
           value={message}
-          onChange={e => setMessage(e.target.value)}
+          onChange={handleMessageChange}
           onKeyPress={handleKeyPress}
           placeholder={placeholder}
+          maxLength={MAX_MESSAGE_LENGTH}
         />
+
+        {/* 문자 수 표시 */}
+        <div className="chat-input__character-counter">
+          {message.length}/{MAX_MESSAGE_LENGTH}
+        </div>
 
         <div className="chat-input__footer">
           {/* 도움말 텍스트 */}

--- a/src/features/Chat/components/ChatMessage/ChatMessage.scss
+++ b/src/features/Chat/components/ChatMessage/ChatMessage.scss
@@ -85,11 +85,15 @@
 
 .chat-message__text {
   align-self: flex-start;
+  overflow-wrap: break-word;
   font-size: $font-size-xxsmall;
   font-weight: $font-weight-regular;
   line-height: 1.3;
   text-align: left;
-  white-space: pre-wrap; // 개행문자 포함
+  white-space: pre-wrap;
+
+  //   word-break: break-word;
+  word-break: break-all;
   color: $black-1;
 
   .dark & {


### PR DESCRIPTION
## 📌 작업 내용 요약
어떤 작업을 했는지 간략히 설명해주세요.

- 채팅 메시지 글자수 제한을 300자로 걸었습니다.
  - 영어는 300자로 잘 제한되는데, 한글은 301자로 자꾸 넘쳐서 핸들러를 구현했습니다.
- 글자수 세기를 넣었습니다. 캡쳐를 보아주세요.
- 영어로 이루어진 메시지가 더이상 메시지 말풍선에서 넘치지 않습니다~~

---

## ✅ 체크리스트
PR을 올리기 전에 아래 항목을 확인했나요?

- [x] 기능 요구사항을 모두 구현했나요?
- [x] 로컬에서 기능을 직접 테스트했나요?
- [x] 코드 컨벤션 및 스타일을 지켰나요?
- [x] 관련된 이슈에 연결했나요?

---

## 🔗 관련 이슈

- Closes #101 

---

## 📎 기타 참고 사항
<img width="450" height="636" alt="image" src="https://github.com/user-attachments/assets/612a7f9b-67ff-4ed2-9bea-a357c35ce8ac" />
