### PR TITLE
[Feature] 입장코드 입력 페이지 API 연동

### DIFF
--- a/src/api/auth.api.ts
+++ b/src/api/auth.api.ts
@@ -1,0 +1,43 @@
+import { apiClient } from './client';
+
+export interface SignInRequest {
+  email: string;
+  password: string;
+}
+
+export interface SignInResponse {
+  status: number;
+  message: string;
+  data: {
+    accessToken: string;
+    user: {
+      id: number;
+      username: string;
+      email: string;
+      nickname: string;
+      profileImageUrl: string;
+    };
+  };
+}
+
+export interface SignOutResponse {
+  status: number;
+  message: string;
+  data: object;
+}
+
+export const authApi = {
+  /**
+   * 로그인 API
+   */
+  signIn: (data: SignInRequest) => {
+    return apiClient.post<SignInRequest, SignInResponse>('/api/auth/signin', data);
+  },
+
+  /**
+   * 로그아웃 API
+   */
+  signOut: () => {
+    return apiClient.post<void, SignOutResponse>('/api/auth/signout');
+  },
+};

--- a/src/api/entrycode.api.ts
+++ b/src/api/entrycode.api.ts
@@ -1,0 +1,37 @@
+import { apiClient } from './client';
+
+export interface Repository {
+  repositoryId: number;
+  repositoryName: string;
+  ownerId: number;
+  ownerName: string;
+  shareLink: string | null;
+  createdAt: string;
+  updatedAt: string;
+  isShared: boolean;
+}
+
+export interface RepositoryAccessResponse {
+  status: number;
+  message: string;
+  data: {
+    access: boolean;
+    repository: Repository;
+  };
+}
+
+export const entrycodeApi = {
+  /**
+   * 레포지토리 입장 권한 확인
+   */
+  getRepositoryAccessibility: (repositoryId: string) => {
+    return apiClient.get<RepositoryAccessResponse>(`/api/repositories/${repositoryId}`);
+  },
+
+  /**
+   * 레포지토리 입장 코드 검증
+   */
+  postRepositoryEntryCode: (repositoryId: string, entryCode: string) => {
+    return apiClient.post(`/api/repositories/${repositoryId}/entrycode`, { entryCode });
+  },
+};

--- a/src/components/molecules/InvitationFormActions/InvitationFormActions.tsx
+++ b/src/components/molecules/InvitationFormActions/InvitationFormActions.tsx
@@ -6,24 +6,19 @@ import './InvitationFormActions.scss';
 interface InvitationFormActionsProps {
   onSubmit?: () => void;
   onGoHome?: () => void;
-  submitDisabled?: boolean;
 }
 
-const InvitationFormActions: React.FC<InvitationFormActionsProps> = ({
-  onSubmit,
-  onGoHome,
-  submitDisabled = false,
-}) => {
+const InvitationFormActions: React.FC<InvitationFormActionsProps> = ({ onSubmit, onGoHome }) => {
   return (
-    <div className="invitation-form-actions">
-      <EntryCodeSubmitButton onClick={onSubmit} disabled={submitDisabled}>
-        입장하기
-      </EntryCodeSubmitButton>
+    <>
+      <div className="invitation-form-actions">
+        <EntryCodeSubmitButton onClick={onSubmit}>입장하기</EntryCodeSubmitButton>
 
-      <button type="button" className="invitation-form-actions__home-link" onClick={onGoHome}>
-        홈으로 돌아가기
-      </button>
-    </div>
+        <button type="button" className="invitation-form-actions__home-link" onClick={onGoHome}>
+          홈으로 돌아가기
+        </button>
+      </div>
+    </>
   );
 };
 

--- a/src/components/organisms/Header/UserProfile/UserProfile.tsx
+++ b/src/components/organisms/Header/UserProfile/UserProfile.tsx
@@ -3,6 +3,7 @@ import styles from './UserProfile.module.scss';
 import ProfileDropdown from '@/components/molecules/Modals/ProfileDropdown/ProfileDropdown';
 import MessageTextIcon from '@/assets/icons/message-text.svg?react';
 import moodHappyIcon from '@/assets/icons/mood-happy.svg';
+import { useAuthStore } from '@/stores/authStore';
 
 interface UserProfileProps {
   variant?: 'lightModeOnly' | 'darkModeSupport';
@@ -16,12 +17,17 @@ const UserProfile = ({
   onChatButtonClick,
 }: UserProfileProps) => {
   const navigate = useNavigate();
+  const { signout } = useAuthStore();
 
-  const handleLogout = () => {
-    // TODO: 로그아웃 처리 로직 구현
-    console.log('로그아웃 처리');
-    // signout(); // authStore 사용 시 주석 해제
-    navigate({ to: '/sign-in' });
+  const handleLogout = async () => {
+    try {
+      await signout();
+      navigate({ to: '/sign-in' });
+    } catch (error) {
+      // 에러 처리 로직 필요
+      console.error('로그아웃 처리 중 오류:', error);
+      navigate({ to: '/sign-in' });
+    }
   };
 
   return (

--- a/src/components/organisms/InvitationLinkForm/InvitationLinkForm.tsx
+++ b/src/components/organisms/InvitationLinkForm/InvitationLinkForm.tsx
@@ -7,9 +7,14 @@ import './InvitationLinkForm.scss';
 interface InvitationLinkFormProps {
   onSubmit?: (code: string) => void;
   onGoHome?: () => void;
+  repositoryName?: string;
 }
 
-const InvitationLinkForm: React.FC<InvitationLinkFormProps> = ({ onSubmit, onGoHome }) => {
+const InvitationLinkForm: React.FC<InvitationLinkFormProps> = ({
+  onSubmit,
+  onGoHome,
+  repositoryName,
+}) => {
   const [invitationCode, setInvitationCode] = useState('');
 
   const handleSubmit = () => {
@@ -32,7 +37,7 @@ const InvitationLinkForm: React.FC<InvitationLinkFormProps> = ({ onSubmit, onGoH
           {/* 프로젝트 정보 표시 */}
           <div className="invitation-form__project-info">
             <div className="invitation-form__project-icon" />
-            <span className="invitation-form__project-name">project07</span>
+            <span className="invitation-form__project-name">{repositoryName}</span>
           </div>
         </div>
 
@@ -48,11 +53,7 @@ const InvitationLinkForm: React.FC<InvitationLinkFormProps> = ({ onSubmit, onGoH
           </div>
 
           {/* 제출 버튼 & 홈으로 이동 버튼 */}
-          <InvitationFormActions
-            onSubmit={handleSubmit}
-            onGoHome={onGoHome}
-            submitDisabled={!invitationCode.trim()}
-          />
+          <InvitationFormActions onSubmit={handleSubmit} onGoHome={onGoHome} />
         </div>
       </div>
     </div>

--- a/src/features/Auth/SignInForm/SignInForm.tsx
+++ b/src/features/Auth/SignInForm/SignInForm.tsx
@@ -27,17 +27,18 @@ export default function SignInForm() {
   const email = watch('email');
   const password = watch('password');
 
-  const onSubmit = (data: SignInFormValues) => {
-    // TODO: 로그인 API 호출
-    console.log('로그인 시도:', data);
-
-    signin();
-    navigate({ to: '/main' });
+  const onSubmit = async (data: SignInFormValues) => {
+    try {
+      await signin(data);
+      navigate({ to: '/main' });
+    } catch (error) {
+      console.error('로그인 실패:', error);
+    }
   };
 
   useEffect(() => {
     if (isLoggedIn) navigate({ to: '/main' });
-  }, [isLoggedIn]);
+  }, [isLoggedIn, navigate]);
 
   const isButtonDisabled = isSubmitting || !email || !password;
 

--- a/src/pages/Auth/InvitationLinkPage/InvitationLinkPage.tsx
+++ b/src/pages/Auth/InvitationLinkPage/InvitationLinkPage.tsx
@@ -1,26 +1,48 @@
 import React from 'react';
+import { useNavigate, useParams, useSearch } from '@tanstack/react-router';
 import InvitationLinkForm from '@/components/organisms/InvitationLinkForm/InvitationLinkForm';
+import { entrycodeApi } from '@/api/entrycode.api';
 
 import './InvitationLinkPage.scss';
 
 const InvitationLinkPage: React.FC = () => {
-  const handleSubmit = (code: string) => {
-    console.log('입장 코드: ', code);
-    // TODO: 입장 로직 구현
+  const navigator = useNavigate();
+  const { repoId } = useParams({ strict: false });
+  const search = useSearch({ strict: false });
+  const repositoryName = search?.repositoryName;
+
+  const handleSubmit = async (code: string) => {
+    try {
+      // 입장 코드 API 호출
+      await entrycodeApi.postRepositoryEntryCode(repoId, code);
+
+      // 성공 시 레포지토리로 이동
+      // TODO - 메시지 토스트로 처리
+      alert('공유 레포지토리에 참여되었습니다.');
+
+      navigator({
+        to: '/$repoId',
+        params: { repoId },
+      });
+    } catch {
+      // TODO - 에러 메시지 토스트로 처리
+      alert('입장 코드 검증에 실패했습니다. 다시 시도해주세요.');
+    }
   };
 
   const handleGoHome = () => {
-    // TODO: 홈으로 이동 로직 구현
+    navigator({ to: '/main' });
   };
 
   return (
-    // TODO: 로그인 된 유저만 접근 가능하도록 구현
-
     <div className="invitation-link-page">
       <main className="invitation-link-page__content">
-        <InvitationLinkForm onSubmit={handleSubmit} onGoHome={handleGoHome} />
+        <InvitationLinkForm
+          onSubmit={handleSubmit}
+          onGoHome={handleGoHome}
+          repositoryName={repositoryName}
+        />
       </main>
-      {/* <Loading /> */}
     </div>
   );
 };

--- a/src/router/routeTree.ts
+++ b/src/router/routeTree.ts
@@ -11,6 +11,7 @@ import { PrivateRepoPageRoute } from './routes/main/private-repo';
 import { SharedByMeRepoRoute } from './routes/main/shared-by-me-repo';
 import { SharedWithMeRepoRoute } from './routes/main/shared-with-me-repo';
 import { repoLayoutRoute, repoPageRoute } from './routes/$repoId';
+import { invitationLinkRoute } from './routes/invitation';
 import { signUpLayoutRoute, signUpFormRoute } from './routes/auth/sign-up';
 import { signUpCompleteRoute } from './routes/auth/sign-up/complete';
 import {
@@ -36,6 +37,7 @@ export const routeTree = rootRoute.addChildren([
     SharedWithMeRepoRoute,
   ]),
   repoLayoutRoute.addChildren([repoPageRoute]),
+  invitationLinkRoute,
   settingsLayoutRoute.addChildren([
     settingsIndexRoute,
     privateSettingsRoute,

--- a/src/router/routes/$repoId/index.tsx
+++ b/src/router/routes/$repoId/index.tsx
@@ -2,6 +2,8 @@ import { createRoute } from '@tanstack/react-router';
 import { rootRoute } from '@/router/root';
 import { RepoLayout } from '@/layouts/RepoLayout/RepoLayout';
 import { RepoPage } from '@/pages/Repo/RepoPage';
+import { checkRepositoryAccess } from '@/utils/repositoryAccessGuard';
+import type { AuthState } from '@/types/authState.types';
 
 export const repoLayoutRoute = createRoute({
   getParentRoute: () => rootRoute,
@@ -13,6 +15,14 @@ export const repoPageRoute = createRoute({
   getParentRoute: () => repoLayoutRoute,
   path: '/',
   component: RepoPage,
+
+  beforeLoad: async ({ params, context }) => {
+    const { auth } = context as { auth: AuthState };
+    const { repoId } = params;
+
+    await checkRepositoryAccess(repoId, auth);
+  },
+
   validateSearch: (search: Record<string, unknown>) => {
     return {
       file: (search.file as string) || undefined,

--- a/src/router/routes/invitation/index.tsx
+++ b/src/router/routes/invitation/index.tsx
@@ -1,0 +1,25 @@
+import { createRoute, redirect } from '@tanstack/react-router';
+import { rootRoute } from '@/router/root';
+import InvitationLinkPage from '@/pages/Auth/InvitationLinkPage/InvitationLinkPage';
+import type { AuthState } from '@/types/authState.types';
+
+export const invitationLinkRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: '/$repoId/share',
+  component: InvitationLinkPage,
+
+  beforeLoad: ({ context }) => {
+    const { auth } = context as { auth: AuthState };
+    if (!auth.isLoggedIn) {
+      // TODO - 토스트로 대체해야 함
+      alert('로그인이 필요한 기능입니다.');
+      throw redirect({ to: '/sign-in' });
+    }
+  },
+
+  validateSearch: (search: Record<string, unknown>) => {
+    return {
+      repositoryName: (search.repositoryName as string) || undefined,
+    };
+  },
+});

--- a/src/stores/authStore.ts
+++ b/src/stores/authStore.ts
@@ -1,14 +1,56 @@
 import { create } from 'zustand';
 import { persist } from 'zustand/middleware';
 import type { AuthState } from '@/types/authState.types';
+import { authApi } from '@/api/auth.api';
+import type { SignInRequest } from '@/api/auth.api';
+
+// 앱 시작시 토큰 확인
+const checkInitialAuth = () => {
+  const token = localStorage.getItem('accessToken');
+  return !!token;
+};
 
 // TODO: 인증 API 연동 후 스토어 확장 여부 확인해야 함.
 export const useAuthStore = create<AuthState>()(
   persist(
     set => ({
-      isLoggedIn: false,
-      signin: () => set({ isLoggedIn: true }),
-      signout: () => set({ isLoggedIn: false }),
+      // 로그인 상태 체크
+      isLoggedIn: checkInitialAuth(),
+
+      // 임시 로그인 API 호출 함수 추가, 추후 signin으로 변경 필요
+      signin: async (data: SignInRequest) => {
+        try {
+          const response = await authApi.signIn(data);
+          const { accessToken } = response.data.data;
+
+          localStorage.setItem('accessToken', accessToken);
+          localStorage.setItem('user', JSON.stringify(response.data.data.user));
+          set({ isLoggedIn: true });
+
+          return response.data;
+        } catch (error) {
+          // 에러 처리 로직 추가 필요
+          alert('로그인에 실패했습니다. 이메일과 비밀번호를 확인해주세요.');
+          console.error('로그인 실패:', error);
+          throw error;
+        }
+      },
+
+      // 로그아웃
+      signout: async () => {
+        try {
+          await authApi.signOut();
+          localStorage.removeItem('accessToken');
+          localStorage.removeItem('user');
+          set({ isLoggedIn: false });
+        } catch (error) {
+          console.error('로그아웃 실패:', error);
+          // 로그아웃 API 실패해도 로컬 스토리지는 정리
+          localStorage.removeItem('accessToken');
+          localStorage.removeItem('user');
+          set({ isLoggedIn: false });
+        }
+      },
     }),
     {
       name: 'auth-storage',

--- a/src/types/authState.types.ts
+++ b/src/types/authState.types.ts
@@ -1,5 +1,7 @@
+import type { SignInRequest, SignInResponse } from '@/api/auth.api';
+
 export interface AuthState {
   isLoggedIn: boolean;
-  signin: () => void;
-  signout: () => void;
+  signin: (data: SignInRequest) => Promise<SignInResponse>;
+  signout: () => Promise<void>;
 }

--- a/src/utils/repositoryAccessGuard.ts
+++ b/src/utils/repositoryAccessGuard.ts
@@ -1,0 +1,50 @@
+import { redirect } from '@tanstack/react-router';
+import { entrycodeApi } from '@/api/entrycode.api';
+import type { AuthState } from '@/types/authState.types';
+
+/**
+ * 레포지토리 접근 권한 체크 로직
+ */
+export const checkRepositoryAccess = async (repoId: string, auth: AuthState) => {
+  // 1. 로그인 체크
+  if (!auth.isLoggedIn) {
+    // TODO - 토스트로 대체해야 함
+    alert('로그인이 필요한 기능입니다.');
+    throw redirect({ to: '/sign-in' });
+  }
+
+  // 2. 레포지토리 접근 권한 체크
+  let response;
+  try {
+    response = await entrycodeApi.getRepositoryAccessibility(repoId);
+  } catch {
+    alert('존재하지 않는 레포지토리입니다.');
+    throw redirect({ to: '/main' });
+  }
+
+  // API 호출 성공 후 접근 권한 체크
+  if (response.data.data.access === true) {
+    // 2-1. access: true
+    // 2-1-a. 내 개인 레포지토리 (isShared: false)
+    // 2-1-b. 내가 참여한 공유 레포지토리 (isShared: true)
+    // TODO - 토스트로 대체해야 함
+    // alert('레포지토리에 입장합니다.');
+  } else {
+    // 2-2. access: false
+    // 2-2-a. 타인의 개인 레포지토리인 경우 (isShared: false)
+    // TODO - 토스트로 대체해야 함
+    const isShared = response.data.data.repository.isShared;
+    if (!isShared) {
+      alert('해당 레포지토리는 공유 레포지토리가 아닙니다.');
+      throw redirect({
+        to: '/main',
+      });
+    }
+    // 2-2-b. 내가 멤버가 아닌 공유 레포지토리인 경우, 입장 코드 입력페이지로 리다이렉트
+    const repositoryName = response.data.data.repository.repositoryName;
+    throw redirect({
+      to: `/${repoId}/share`,
+      search: { repositoryName },
+    });
+  }
+};


### PR DESCRIPTION
## 📌 작업 내용 요약

- {{baseURL}}/{$repoId}로 접근하는 경우 액세스 권한을 체크합니다.
1. 로그인 되지 않은 경우, 로그인 페이지로 이동합니다.
2. 로그인 된 사용자의 경우
  2-1. 내 개인 레포지토리이거나, 내가 참여한 공유 레포지토리인 경우 레포지토리로 입장합니다.
  2-2. 타인의 개인 레포지토리이거나, 내가 참여하지 않은 공유 레포지토리의 경우 /{$repoId}/share로 이동하여 입장 코드 검증을 수행하게 됩니다.

- 현재 모든 안내 메시지는 alert로 작성되어 있으며, 추후 Toast로 변경될 예정입니다.

- 임시로 로그인 및 로그아웃 기능이 연결되어 있습니다.
- /sign-in 페이지에서 로그인을 수행할 수 있습니다.
  - 로그인 성공시, localStorage에 있는 auth-storage의 isLoggedIn이 true로 변경됩니다.
  - 로그인 시 받아온 user의 객체가 localStorage에 저장됩니다.
  - 다양한 에러 처리까지는 반영하지 못했습니다.
- 헤더의 UserProfile 컴포넌트 드롭다운에서 로그아웃을 수행할 수 있습니다.
  - isLoggedIn이 false로 변경됩니다.
  - user의 객체가 localStorage에서 삭제됩니다.

---

## ✅ 체크리스트
PR을 올리기 전에 아래 항목을 확인했나요?

- [x] 기능 요구사항을 모두 구현했나요?
- [x] 로컬에서 기능을 직접 테스트했나요?
- [x] 코드 컨벤션 및 스타일을 지켰나요?
- [x] 관련된 이슈에 연결했나요?

---

## 🔗 관련 이슈

- Closes #95 

---

## 📎 기타 참고 사항

To. 소뎅님께
Auth 관련하여 수정된 파일들은 아래와 같습니다. 감샤합니당.
1. api/auth.api.ts
로그인 및 로그아웃 API 추가

2. types/authState.types.ts
로그인 및 로그아웃 메서드 타입 정의 수정

3. AuthStore
로그인 상태 체크 및 API 연결

4. SignInForm
로그인 API 호출

5. UserProfile 컴포넌트
로그아웃 API 호출