### PR TITLE
fix/DP-187/meatball-modal-img

### DIFF
--- a/src/components/molecules/Modals/ToggleInputMenuItem/ToggleInputMenuItem.module.scss
+++ b/src/components/molecules/Modals/ToggleInputMenuItem/ToggleInputMenuItem.module.scss
@@ -146,8 +146,10 @@
 }
 
 .eyeIcon {
+  display: block;
   width: 16px;
   height: 16px;
+  margin: auto;
   opacity: 0.6;
   transition: opacity 0.2s ease;
 

--- a/src/components/molecules/Modals/ToggleInputMenuItem/ToggleInputMenuItem.tsx
+++ b/src/components/molecules/Modals/ToggleInputMenuItem/ToggleInputMenuItem.tsx
@@ -1,6 +1,8 @@
 import React, { useState } from 'react';
 import clsx from 'clsx';
 import styles from './ToggleInputMenuItem.module.scss';
+import EyeIcon from '@/assets/icons/eye.svg?react';
+import EyeClosedIcon from '@/assets/icons/eye-closed.svg?react';
 
 export interface ToggleInputMenuItemProps {
   label: string;
@@ -129,11 +131,11 @@ const ToggleInputMenuItem: React.FC<ToggleInputMenuItemProps> = ({
             onClick={handlePasswordToggle}
             aria-label={showPassword ? '비밀번호 숨기기' : '비밀번호 보기'}
           >
-            <img
-              src={showPassword ? 'src/assets/icons/eye.svg' : 'src/assets/icons/eye-closed.svg'}
-              alt={showPassword ? '숨기기' : '보기'}
-              className={styles.eyeIcon}
-            />
+            {showPassword ? (
+              <EyeIcon className={styles.eyeIcon} />
+            ) : (
+              <EyeClosedIcon className={styles.eyeIcon} />
+            )}
           </button>
         )}
       </div>


### PR DESCRIPTION
## 🔀 PR 제목
- [FE][Fix] 공유한 레포 미트볼 모달 입장코드 input 이미지 안보이는 문제 해결 

---

## 📌 작업 내용 요약
- 공유한 레포 미트볼 모달 입장코드 섹션의 input 이미지 안보이는 문제를 해결
---

## ✅ 체크리스트
PR을 올리기 전에 아래 항목을 확인했나요?

- [x] 기능 요구사항을 모두 구현했나요?
- [x] 로컬에서 기능을 직접 테스트했나요?
- [x] 코드 컨벤션 및 스타일을 지켰나요?
- [x] 관련된 이슈에 연결했나요?

---

## 🔗 관련 이슈

- Closes #177 
---

## 📎 기타 참고 사항
- 공유한 레포 미트볼 모달 입장코드 확인 섹션의 input 의 눈 이미지가 보이는 않는 문제 해결 했습니다.
