### PR TITLE
Feature/dp 189/header path area

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -26,6 +26,7 @@
     "Avenir",
     "eslint",
     "filetree",
+    "partialize",
     "pnpm",
     "prettierrc",
     "Resizer",

--- a/src/components/organisms/Header/PathArea/PathArea.module.scss
+++ b/src/components/organisms/Header/PathArea/PathArea.module.scss
@@ -41,7 +41,7 @@
   cursor: pointer;
 
   &:hover:not(:disabled) {
-    opacity: 0.7;
+    color: $orange;
   }
 
   &:disabled {

--- a/src/components/organisms/Header/PathArea/PathArea.module.scss
+++ b/src/components/organisms/Header/PathArea/PathArea.module.scss
@@ -1,0 +1,57 @@
+@use '@/styles/variables' as *;
+
+.pathArea {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  width: 400px;
+  padding: 0.5rem 1rem;
+  border-radius: 8px;
+  font-size: $font-size-xsmall;
+  font-weight: normal;
+  color: var(--header-text);
+  background-color: var(--header-path-bg);
+
+  @media (width <= 1400px) {
+    width: 300px;
+    padding: 0.5rem 0.75rem;
+  }
+}
+
+.path {
+  flex: 1;
+  min-width: 0;
+  min-height: 1.2em;
+  margin-right: 0.5rem;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.iconButton {
+  display: flex;
+  flex-shrink: 0;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
+  border: none;
+  color: inherit;
+  background: none;
+  transition: opacity 0.2s ease;
+  cursor: pointer;
+
+  &:hover:not(:disabled) {
+    opacity: 0.7;
+  }
+
+  &:disabled {
+    opacity: 0.4;
+    cursor: not-allowed;
+  }
+}
+
+.icon {
+  flex-shrink: 0;
+  width: 18px;
+  height: 18px;
+}

--- a/src/components/organisms/Header/PathArea/PathArea.tsx
+++ b/src/components/organisms/Header/PathArea/PathArea.tsx
@@ -3,10 +3,12 @@ import { useParams } from '@tanstack/react-router';
 import styles from './PathArea.module.scss';
 import NoteMultipleIcon from '@/assets/icons/note-multiple.svg?react';
 import { useTabStore } from '@/stores/tabStore';
+import { useToastStore } from '@/stores/toastStore';
 
 const PathArea = () => {
   const { repoId } = useParams({ strict: false });
   const { openTabs } = useTabStore();
+  const { showToast } = useToastStore();
   const [currentPath, setCurrentPath] = useState('');
   const [displayPath, setDisplayPath] = useState('');
 
@@ -47,9 +49,26 @@ const PathArea = () => {
     if (currentPath) {
       try {
         await navigator.clipboard.writeText(currentPath);
+
+        // 성공 토스트 표시
+        showToast({
+          type: 'success',
+          message: '파일 경로가 클립보드에 복사되었습니다',
+          duration: 2000,
+          showCloseButton: true,
+        });
+
         console.log('경로가 클립보드에 복사되었습니다:', currentPath);
       } catch (error) {
         console.error('클립보드 복사 실패:', error);
+
+        // 실패 토스트 표시
+        showToast({
+          type: 'error',
+          message: '클립보드 복사에 실패했습니다',
+          duration: 3000,
+          showCloseButton: true,
+        });
       }
     }
   };

--- a/src/components/organisms/Header/PathArea/PathArea.tsx
+++ b/src/components/organisms/Header/PathArea/PathArea.tsx
@@ -1,0 +1,74 @@
+import { useEffect, useState } from 'react';
+import { useParams } from '@tanstack/react-router';
+import styles from './PathArea.module.scss';
+import NoteMultipleIcon from '@/assets/icons/note-multiple.svg?react';
+import { useTabStore } from '@/stores/tabStore';
+
+const PathArea = () => {
+  const { repoId } = useParams({ strict: false });
+  const { openTabs } = useTabStore();
+  const [currentPath, setCurrentPath] = useState('');
+  const [displayPath, setDisplayPath] = useState('');
+
+  // 활성 탭의 경로 가져오기
+  useEffect(() => {
+    if (repoId) {
+      const activeTab = openTabs.find(tab => tab.isActive && tab.id.startsWith(`${repoId}/`));
+
+      if (activeTab) {
+        const filePath = activeTab.path;
+        setCurrentPath(filePath);
+      } else {
+        setCurrentPath('');
+      }
+    } else {
+      setCurrentPath('');
+    }
+  }, [openTabs, repoId]);
+
+  // 경로가 너무 길면 앞부분을 ...으로 처리
+  useEffect(() => {
+    if (!currentPath) {
+      setDisplayPath('');
+      return;
+    }
+
+    const maxLength = 50; // 최대 표시 길이
+
+    if (currentPath.length > maxLength) {
+      setDisplayPath(`...${currentPath.slice(-(maxLength - 3))}`);
+    } else {
+      setDisplayPath(currentPath);
+    }
+  }, [currentPath]);
+
+  // 클립보드 복사 함수
+  const handleCopyToClipboard = async () => {
+    if (currentPath) {
+      try {
+        await navigator.clipboard.writeText(currentPath);
+        console.log('경로가 클립보드에 복사되었습니다:', currentPath);
+      } catch (error) {
+        console.error('클립보드 복사 실패:', error);
+      }
+    }
+  };
+
+  return (
+    <div className={styles.pathArea}>
+      <div className={styles.path} title={currentPath || ''}>
+        {displayPath}
+      </div>
+      <button
+        className={styles.iconButton}
+        onClick={handleCopyToClipboard}
+        title={currentPath ? '경로 복사' : '복사할 경로가 없습니다'}
+        disabled={!currentPath}
+      >
+        <NoteMultipleIcon className={styles.icon} />
+      </button>
+    </div>
+  );
+};
+
+export default PathArea;

--- a/src/components/organisms/Header/RepoHeader/RepoHeader.module.scss
+++ b/src/components/organisms/Header/RepoHeader/RepoHeader.module.scss
@@ -41,31 +41,6 @@
   }
 }
 
-.pathArea {
-  display: flex;
-  align-items: center;
-  gap: 0.5rem;
-  max-width: 400px;
-  min-width: 0;
-  padding: 0.5rem 6rem;
-  border-radius: 8px;
-  font-size: $font-size-xsmall;
-  color: var(--header-text);
-  background-color: var(--header-path-bg);
-
-  @media (width <= 1400px) {
-    max-width: 300px;
-    padding: 0.5rem 3rem;
-  }
-}
-
-.path {
-  min-width: 0;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
 .icon {
   flex-shrink: 0;
   width: 18px;

--- a/src/components/organisms/Header/RepoHeader/RepoHeader.tsx
+++ b/src/components/organisms/Header/RepoHeader/RepoHeader.tsx
@@ -5,7 +5,7 @@ import Logo from '@/components/atoms/Logo/Logo';
 import UserProfile from '@/components/organisms/Header/UserProfile/UserProfile';
 import Toggle from '@/components/atoms/Toggle/Toggle';
 import MessageTextIcon from '@/assets/icons/message-text.svg?react';
-import NoteMultipleIcon from '@/assets/icons/note-multiple.svg?react';
+import PathArea from '@/components/organisms/Header/PathArea/PathArea';
 import useGetRepositorySettings from '@/hooks/settings/useGetRepositorySettings';
 import useRepoSettingsStore from '@/stores/repoSettingsStore';
 
@@ -37,10 +37,7 @@ const RepoHeader = ({ onChatButtonClick, isChatOpen = false }: RepoHeaderProps) 
       </div>
 
       <div className={styles.center}>
-        <div className={styles.pathArea}>
-          <div className={styles.path}>project-name/section01/chapter01.ts</div>
-          <NoteMultipleIcon className={styles.icon} />
-        </div>
+        <PathArea />
 
         {isSharedRepo && (
           <button


### PR DESCRIPTION
## 🔀 PR 제목
- [FE][Feature] Header의 PathArea 영역 제작

---

## 📌 작업 내용 요약
- RepoHeader의 PathArea를 컴포넌트로 제작
- RepoHeader에 적용
- 다크모드 지원
- 경로 복사 기능 구현
- 토스트 적용

---

## ✅ 체크리스트
PR을 올리기 전에 아래 항목을 확인했나요?

- [x] 기능 요구사항을 모두 구현했나요?
- [x] 로컬에서 기능을 직접 테스트했나요?
- [x] 코드 컨벤션 및 스타일을 지켰나요?
- [x] 관련된 이슈에 연결했나요?

---

## 🔗 관련 이슈

예시:
- Closes  #179
---

## 📎 기타 참고 사항
- `src\stores\tabStore.ts` 를 사용하였습니당