### PR TITLE
Feature/dp 181/terminal

### DIFF
--- a/src/api/codeRunner.ts
+++ b/src/api/codeRunner.ts
@@ -20,3 +20,18 @@ export const executeRepository = async (
   );
   return response.data.data;
 };
+
+export interface RepositoryStopResponse {
+  repositoryId: number;
+  stopped: boolean;
+  message: string;
+}
+
+export const stopRepository = async (
+  repositoryId: number | string
+): Promise<RepositoryStopResponse> => {
+  const response = await apiClient.delete<undefined, { data: RepositoryStopResponse }>(
+    `/api/repositories/${repositoryId}/stop`
+  );
+  return response.data.data;
+};

--- a/src/api/codeRunner.ts
+++ b/src/api/codeRunner.ts
@@ -43,7 +43,7 @@ export interface RepositoryLogsResponse {
 
 export const getRepositoryLogs = async (
   repositoryId: number | string,
-  lines = 50,
+  lines = 100,
   since = '5m'
 ): Promise<RepositoryLogsResponse> => {
   const response = await apiClient.get<{ data: RepositoryLogsResponse }>(

--- a/src/api/codeRunner.ts
+++ b/src/api/codeRunner.ts
@@ -35,3 +35,20 @@ export const stopRepository = async (
   );
   return response.data.data;
 };
+
+export interface RepositoryLogsResponse {
+  logs: string;
+  port: number | null;
+}
+
+export const getRepositoryLogs = async (
+  repositoryId: number | string,
+  lines = 50,
+  since = '5m'
+): Promise<RepositoryLogsResponse> => {
+  const response = await apiClient.get<{ data: RepositoryLogsResponse }>(
+    `/api/repositories/${repositoryId}/logs`,
+    { lines, since }
+  );
+  return response.data.data;
+};

--- a/src/api/codeRunner.ts
+++ b/src/api/codeRunner.ts
@@ -1,0 +1,22 @@
+import { apiClient } from '@/api/client';
+
+export interface RepositoryExecuteResponse {
+  uuid: string;
+  s3Url: string;
+  port: number;
+  message: string;
+  executionId: string;
+  status: string;
+  output: string;
+  error: string;
+  executionTime: number;
+}
+
+export const executeRepository = async (
+  repositoryId: number | string
+): Promise<RepositoryExecuteResponse> => {
+  const response = await apiClient.post<undefined, RepositoryExecuteResponse>(
+    `/api/repositories/${repositoryId}/execute`
+  );
+  return response.data;
+};

--- a/src/api/codeRunner.ts
+++ b/src/api/codeRunner.ts
@@ -15,8 +15,8 @@ export interface RepositoryExecuteResponse {
 export const executeRepository = async (
   repositoryId: number | string
 ): Promise<RepositoryExecuteResponse> => {
-  const response = await apiClient.post<undefined, RepositoryExecuteResponse>(
+  const response = await apiClient.post<undefined, { data: RepositoryExecuteResponse }>(
     `/api/repositories/${repositoryId}/execute`
   );
-  return response.data;
+  return response.data.data;
 };

--- a/src/api/codeRunner.ts
+++ b/src/api/codeRunner.ts
@@ -44,7 +44,7 @@ export interface RepositoryLogsResponse {
 export const getRepositoryLogs = async (
   repositoryId: number | string,
   lines = 100,
-  since = '5m'
+  since = '10m'
 ): Promise<RepositoryLogsResponse> => {
   const response = await apiClient.get<{ data: RepositoryLogsResponse }>(
     `/api/repositories/${repositoryId}/logs`,

--- a/src/features/CodeRunner/CodeRunner.scss
+++ b/src/features/CodeRunner/CodeRunner.scss
@@ -149,3 +149,35 @@
     }
   }
 }
+
+.code-runner__logs-block {
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+  margin: 8px 0 0;
+  padding: 14px 18px;
+  border-radius: 8px;
+  overflow-x: auto;
+  font-family: $font-family-inter;
+  font-size: $font-size-xxsmall;
+  font-weight: $font-weight-regular;
+  line-height: 1.7;
+  text-align: left;
+  color: $gray-5;
+  background-color: $white-1;
+
+  .dark & {
+    color: $white-1;
+    background-color: $black-1;
+  }
+}
+
+.code-runner__logs-line {
+  text-align: left;
+  white-space: pre;
+  word-break: break-all;
+
+  .dark & {
+    color: $white-1;
+  }
+}

--- a/src/features/CodeRunner/CodeRunner.scss
+++ b/src/features/CodeRunner/CodeRunner.scss
@@ -154,9 +154,6 @@
   display: flex;
   flex-direction: column;
   gap: 0;
-  margin: 8px 0 0;
-  padding: 14px 18px;
-  border-radius: 8px;
   overflow-x: auto;
   font-family: $font-family-inter;
   font-size: $font-size-xxsmall;
@@ -180,4 +177,13 @@
   .dark & {
     color: $white-1;
   }
+}
+
+.code-runner__open-url-link {
+  font-family: $font-family-inter;
+  font-size: $font-size-xsmall;
+  font-weight: $font-weight-semi-bold;
+  text-decoration: underline;
+  color: $blue-1;
+  cursor: pointer;
 }

--- a/src/features/CodeRunner/CodeRunner.tsx
+++ b/src/features/CodeRunner/CodeRunner.tsx
@@ -62,7 +62,15 @@ export function CodeRunner(_props: CodeRunnerProps) {
       {/* 제어 섹션 */}
       <div className="code-runner__controls">
         {/* 실행 버튼 */}
-        <button className="code-runner__control-button" aria-label="실행">
+        <button
+          className="code-runner__control-button"
+          aria-label="실행"
+          onClick={() => {
+            if (currentCommand.trim()) {
+              executeCommand(currentCommand.trim());
+            }
+          }}
+        >
           <svg fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
             <path d="M10 20H8V4h2v2h2v3h2v2h2v2h-2v2h-2v3h-2v2z" fill="currentColor" />
           </svg>

--- a/src/features/CodeRunner/CodeRunner.tsx
+++ b/src/features/CodeRunner/CodeRunner.tsx
@@ -98,7 +98,7 @@ export function CodeRunner(props: CodeRunnerProps) {
           // 기존 logs 출력 지우고 새로
           setTimeout(() => {
             executeCommand('logs');
-          }, 350);
+          }, 1000);
         }
       },
       onError: (e: unknown) => {

--- a/src/features/CodeRunner/CodeRunner.tsx
+++ b/src/features/CodeRunner/CodeRunner.tsx
@@ -156,22 +156,11 @@ export function CodeRunner(props: CodeRunnerProps) {
       {
         command: 'logs',
         output: (
-          <div
-            style={{
-              fontFamily: 'Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace',
-              color: '#fff',
-              background: '#181a20',
-              fontSize: '1em',
-              lineHeight: 1.7,
-              padding: '16px',
-              borderRadius: 8,
-              overflow: 'auto',
-              whiteSpace: 'pre-wrap',
-              textAlign: 'left',
-            }}
-          >
+          <div className="code-runner__logs-block">
             {streamedLogLines.map((line, idx) => (
-              <div key={idx}>{typeof line === 'string' ? line.trimStart() : ''}</div>
+              <div key={idx} className="code-runner__logs-line">
+                {typeof line === 'string' ? line.trimStart() : ''}
+              </div>
             ))}
           </div>
         ),

--- a/src/features/CodeRunner/CodeRunner.tsx
+++ b/src/features/CodeRunner/CodeRunner.tsx
@@ -44,7 +44,7 @@ export function CodeRunner(props: CodeRunnerProps) {
   const codeRunnerExecute = useCodeRunnerExecute(props.repoId);
   const codeRunnerStop = useCodeRunnerStop(props.repoId);
 
-  // logs: enabled=false, refetch로 직접 요청!
+  // logs: enabled=false, refetch로 직접 요청
   const { data: logsData, refetch: refetchLogs } = useCodeRunnerLogs(props.repoId);
 
   // logs 명령어 처리: refetchLogs() 호출, streaming 준비
@@ -92,6 +92,14 @@ export function CodeRunner(props: CodeRunnerProps) {
             timestamp: new Date(),
           },
         ]);
+
+        // ★★★ run 실행 후 자동 logs 호출
+        if (command === 'run' || command === '') {
+          // 기존 logs 출력 지우고 새로
+          setTimeout(() => {
+            executeCommand('logs');
+          }, 350);
+        }
       },
       onError: (e: unknown) => {
         let errorMessage = '실패';
@@ -226,7 +234,7 @@ export function CodeRunner(props: CodeRunnerProps) {
           className="code-runner__control-button"
           aria-label="실행"
           onClick={() => {
-            executeCommand(currentCommand.trim());
+            executeCommand(currentCommand.trim() || 'run');
           }}
         >
           <svg fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">

--- a/src/features/CodeRunner/CodeRunner.tsx
+++ b/src/features/CodeRunner/CodeRunner.tsx
@@ -77,7 +77,7 @@ export function CodeRunner(props: CodeRunnerProps) {
               href={url}
               target="_blank"
               rel="noopener noreferrer"
-              style={{ color: '#53aaff', textDecoration: 'underline', cursor: 'pointer' }}
+              className="code-runner__open-url-link"
             >
               {url}
             </a>

--- a/src/features/CodeRunner/CodeRunner.tsx
+++ b/src/features/CodeRunner/CodeRunner.tsx
@@ -6,6 +6,7 @@ import './CodeRunner.scss';
 
 export interface CodeRunnerProps {
   repoId?: number | string;
+  repositoryName?: string;
 }
 
 interface CommandHistory {
@@ -133,7 +134,9 @@ export function CodeRunner(props: CodeRunnerProps) {
               {item.command && (
                 <div className="code-runner__output-line">
                   <span className="code-runner__prompt">
-                    <span className="code-runner__project-path">my/project-name</span>
+                    <span className="code-runner__project-path">
+                      my/{props.repositoryName ?? 'project-name'}
+                    </span>
                   </span>
                   <span className="code-runner__command">{item.command}</span>
                 </div>
@@ -155,7 +158,9 @@ export function CodeRunner(props: CodeRunnerProps) {
         <div className="code-runner__input-section">
           <div className="code-runner__input-line">
             <span className="code-runner__prompt">
-              <span className="code-runner__project-path">my/project-name</span>
+              <span className="code-runner__project-path">
+                my/{props.repositoryName ?? 'project-name'}
+              </span>
             </span>
             <input
               ref={inputRef}

--- a/src/features/CodeRunner/CodeRunner.tsx
+++ b/src/features/CodeRunner/CodeRunner.tsx
@@ -18,7 +18,7 @@ export function CodeRunner(props: CodeRunnerProps) {
   const [commandHistory, setCommandHistory] = useState<CommandHistory[]>([
     {
       command: '',
-      output: 'Hello Typescript!',
+      output: 'Hello DeepWebIDE!',
       timestamp: new Date(),
     },
   ]);

--- a/src/features/CodeRunner/CodeRunner.tsx
+++ b/src/features/CodeRunner/CodeRunner.tsx
@@ -3,6 +3,7 @@ import type { KeyboardEvent } from 'react';
 import { useThemeStore } from '@/stores/themeStore';
 import { useCodeRunnerExecute } from '@/features/Repo/codeRunner/hooks/useCodeRunnerExecute';
 import './CodeRunner.scss';
+import type { JSX } from 'react/jsx-runtime';
 
 export interface CodeRunnerProps {
   repoId?: number | string;

--- a/src/features/Repo/codeRunner/hooks/useCodeRunnerExecute.ts
+++ b/src/features/Repo/codeRunner/hooks/useCodeRunnerExecute.ts
@@ -1,0 +1,11 @@
+import { useMutation } from '@tanstack/react-query';
+import { executeRepository } from '@/api/codeRunner';
+
+export const useCodeRunnerExecute = (repositoryId?: number | string) => {
+  return useMutation({
+    mutationFn: async () => {
+      if (!repositoryId) throw new Error('repositoryId is required');
+      return await executeRepository(repositoryId);
+    },
+  });
+};

--- a/src/features/Repo/codeRunner/hooks/useCodeRunnerExecute.ts
+++ b/src/features/Repo/codeRunner/hooks/useCodeRunnerExecute.ts
@@ -1,8 +1,9 @@
 import { useMutation } from '@tanstack/react-query';
 import { executeRepository } from '@/api/codeRunner';
+import type { RepositoryExecuteResponse } from '@/api/codeRunner';
 
 export const useCodeRunnerExecute = (repositoryId?: number | string) => {
-  return useMutation({
+  return useMutation<RepositoryExecuteResponse, Error, void>({
     mutationFn: async () => {
       if (!repositoryId) throw new Error('repositoryId is required');
       return await executeRepository(repositoryId);

--- a/src/features/Repo/codeRunner/hooks/useCodeRunnerLogs.ts
+++ b/src/features/Repo/codeRunner/hooks/useCodeRunnerLogs.ts
@@ -1,0 +1,16 @@
+import { useQuery } from '@tanstack/react-query';
+import { getRepositoryLogs } from '@/api/codeRunner';
+import type { RepositoryLogsResponse } from '@/api/codeRunner';
+
+export const useCodeRunnerLogs = (repositoryId?: number | string) => {
+  return useQuery<RepositoryLogsResponse>({
+    queryKey: ['repositoryLogs', repositoryId],
+    queryFn: () => {
+      if (!repositoryId) throw new Error('repositoryId is required');
+      return getRepositoryLogs(repositoryId);
+    },
+    enabled: false, // 항상 refetch로만 요청
+    refetchOnWindowFocus: false, // 포커스 때 자동재요청 방지
+    retry: false, // 실패해도 자동재요청 방지
+  });
+};

--- a/src/features/Repo/codeRunner/hooks/useCodeRunnerStop.ts
+++ b/src/features/Repo/codeRunner/hooks/useCodeRunnerStop.ts
@@ -1,0 +1,12 @@
+import { useMutation } from '@tanstack/react-query';
+import { stopRepository } from '@/api/codeRunner';
+import type { RepositoryStopResponse } from '@/api/codeRunner';
+
+export const useCodeRunnerStop = (repositoryId?: number | string) => {
+  return useMutation<RepositoryStopResponse, Error, void>({
+    mutationFn: async () => {
+      if (!repositoryId) throw new Error('repositoryId is required');
+      return await stopRepository(repositoryId);
+    },
+  });
+};

--- a/src/pages/Repo/RepoPage.tsx
+++ b/src/pages/Repo/RepoPage.tsx
@@ -184,7 +184,7 @@ export function RepoPage() {
 
         {/* 터미널 */}
         <div className={styles.terminalSection}>
-          <CodeRunner repoId={repoId} />
+          <CodeRunner repoId={repoId} repositoryName={repositoryInfo?.repositoryName} />
         </div>
       </div>
     </div>


### PR DESCRIPTION
## 🔀 PR 제목

- [Feature] 코드러너(터미널) 명령 실행/중지/로그 기능 및 실시간 로그 시뮬레이션 구현

---

## 📌 작업 내용 요약

- CodeRunner(터미널) 컴포넌트
  - 명령어 입력(run, stop, logs) 및 실행/중지 버튼 동작 구현
  - 명령 실행 결과/오류/실행 URL 등 터미널에 출력
  - run 명령 및 실행 버튼 시 자동으로 이어서 logs 명령 수행
  - 로그 명령 시 API에서 전체 로그를 받아 한 줄씩 출력(실시간처럼 보임)
  - 로그 첫 줄부터 전체 표시, 로그 속도(setInterval) 조정 가능
  - 명령 입력이 없을 때 실행 버튼 누르면 기본적으로 run 실행

- 스타일 및 디자인
  - 각 로그 라인 별도로 <div> 처리 및 좌측 정렬, 고정폭 폰트 적용
  - 라이트/다크모드 대응, 기존 디자인 컨벤션 유지
  - 로그 블록/라인에 별도 클래스(code-runner__logs-block, code-runner__logs-line) 적용
  
- API 연동
  - 레포지토리 실행/중지/로그 조회 API와 연동 완료
  - 로그 since, lines 파라미터 조정 (기본 10분, 100줄)

https://github.com/user-attachments/assets/83e96120-0f2c-44c4-ab4b-7c0938a18cbc


---

## ✅ 체크리스트
PR을 올리기 전에 아래 항목을 확인했나요?

- [ ] 기능 요구사항을 모두 구현했나요?
- [ ] 로컬에서 기능을 직접 테스트했나요?
- [ ] 코드 컨벤션 및 스타일을 지켰나요?
- [ ] 관련된 이슈에 연결했나요?

---

## 🔗 관련 이슈

- Closes #169 
- Related to #120

---

## 📎 기타 참고 사항

- YJS는 @ssoogit 님의 작업이 끝나면 이어서 하겠습니다.
