### PR TITLE
Feature/dp 199/login and token

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -31,6 +31,7 @@
     "prettierrc",
     "Resizer",
     "savepoint",
+    "stompjs",
     "stylelint",
     "tanstack",
     "vite",

--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -8,6 +8,25 @@ const api = axios.create({
   headers: { 'Content-Type': 'application/json' },
 });
 
+// 토큰 갱신 중인지 확인하는 플래그
+let isRefreshing = false;
+let failedQueue: Array<{
+  resolve: (token: string) => void;
+  reject: (error: unknown) => void;
+}> = [];
+
+const processQueue = (error: unknown, token: string | null = null) => {
+  failedQueue.forEach(({ resolve, reject }) => {
+    if (error) {
+      reject(error);
+    } else {
+      resolve(token!);
+    }
+  });
+
+  failedQueue = [];
+};
+
 api.interceptors.request.use(config => {
   const token = sessionStorage.getItem('accessToken');
   if (token) config.headers.Authorization = `Bearer ${token}`;
@@ -17,6 +36,58 @@ api.interceptors.request.use(config => {
 api.interceptors.response.use(
   res => res,
   async error => {
+    const originalRequest = error.config;
+
+    // 401 에러이고 아직 재시도하지 않은 요청인 경우
+    if (error.response?.status === 401 && !originalRequest._retry) {
+      if (isRefreshing) {
+        // 이미 토큰 갱신 중이면 큐에 추가하고 대기
+        return new Promise((resolve, reject) => {
+          failedQueue.push({ resolve, reject });
+        })
+          .then(token => {
+            originalRequest.headers.Authorization = `Bearer ${token}`;
+            return api(originalRequest);
+          })
+          .catch(err => {
+            return Promise.reject(err);
+          });
+      }
+
+      originalRequest._retry = true;
+      isRefreshing = true;
+
+      try {
+        // 토큰 갱신 요청
+        const response = await api.post('/api/auth/token');
+        const { accessToken } = response.data.data;
+
+        // 새 토큰을 세션스토리지에 저장
+        sessionStorage.setItem('accessToken', accessToken);
+
+        // 대기 중인 요청들 처리
+        processQueue(null, accessToken);
+
+        // 원래 요청에 새 토큰으로 재시도
+        originalRequest.headers.Authorization = `Bearer ${accessToken}`;
+        return api(originalRequest);
+      } catch (refreshError) {
+        // 토큰 갱신 실패 시 로그아웃 처리
+        processQueue(refreshError, null);
+
+        // 세션스토리지 정리
+        sessionStorage.removeItem('accessToken');
+        sessionStorage.removeItem('user');
+
+        // 로그인 페이지로 리다이렉트 (필요시)
+        window.location.href = '/login';
+
+        return Promise.reject(refreshError);
+      } finally {
+        isRefreshing = false;
+      }
+    }
+
     return Promise.reject(error);
   }
 );

--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -9,7 +9,7 @@ const api = axios.create({
 });
 
 api.interceptors.request.use(config => {
-  const token = localStorage.getItem('accessToken');
+  const token = sessionStorage.getItem('accessToken');
   if (token) config.headers.Authorization = `Bearer ${token}`;
   return config;
 });

--- a/src/features/Auth/SignInForm/SignInForm.module.scss
+++ b/src/features/Auth/SignInForm/SignInForm.module.scss
@@ -19,7 +19,13 @@
   transform: translateY(-0.05rem);
 }
 
+.sectionDepart {
+  margin-top: 3.5rem;
+  border-bottom: 1px solid #cccccc;
+}
+
 .loginBtn {
   width: 100%;
+  margin-top: 2rem;
   margin-bottom: 1rem;
 }

--- a/src/features/Auth/SignInForm/SignInForm.tsx
+++ b/src/features/Auth/SignInForm/SignInForm.tsx
@@ -69,12 +69,7 @@ export default function SignInForm() {
         <PasswordInput id="password" placeholder="********" {...register('password')} />
       </FormField>
 
-      <div className={styles.options}>
-        <label className={styles.checkbox}>
-          <input type="checkbox" />
-          <p>이메일 저장하기</p>
-        </label>
-      </div>
+      <div className={styles.sectionDepart}></div>
 
       <Button
         variant={isButtonDisabled ? 'general' : 'active'}

--- a/src/hooks/chat/useStompChat.ts
+++ b/src/hooks/chat/useStompChat.ts
@@ -16,7 +16,7 @@ const useStompChat = (url: string, repositoryId: number) => {
   const [connectedCount, setConnectedCount] = useState<number>(1);
   const [isConnected, setIsConnected] = useState(false);
 
-  const token = localStorage.getItem('accessToken');
+  const token = sessionStorage.getItem('accessToken');
   const params = new URLSearchParams();
 
   if (token) params.append('token', token);

--- a/src/hooks/chat/useWebSocketChat.ts
+++ b/src/hooks/chat/useWebSocketChat.ts
@@ -156,7 +156,7 @@ export const useWebSocketChat = ({
       setIsLoading(true);
 
       const config = getWebSocketConfig();
-      const token = localStorage.getItem('accessToken');
+      const token = sessionStorage.getItem('accessToken');
 
       const wsUrl = buildWebSocketUrl(config.chatWsUrl, {
         roomId,
@@ -240,7 +240,7 @@ export const useWebSocketChat = ({
         data: newMessage,
         roomId,
         userId,
-        token: localStorage.getItem('accessToken') || undefined,
+        token: sessionStorage.getItem('accessToken') || undefined,
       });
     },
     [userId, userName, profileImageUrl, roomId, sendWebSocketMessage]

--- a/src/hooks/repo/useYjsSavePoint.ts
+++ b/src/hooks/repo/useYjsSavePoint.ts
@@ -60,7 +60,7 @@ export function useYjsSavePoint(repositoryId: number) {
       const response = await fetch(`/api/repositories/${repositoryId}/histories`, {
         credentials: 'include',
         headers: {
-          Authorization: `Bearer ${localStorage.getItem('accessToken')}`,
+          Authorization: `Bearer ${sessionStorage.getItem('accessToken')}`,
           'Content-Type': 'application/json',
         },
       });

--- a/src/pages/Auth/SignInPage/SignInPage.tsx
+++ b/src/pages/Auth/SignInPage/SignInPage.tsx
@@ -15,7 +15,7 @@ export default function SignInPage() {
 
   useEffect(() => {
     if (isLoggedIn) navigate({ to: '/main' });
-  }, [isLoggedIn]);
+  }, [isLoggedIn, navigate]);
 
   return (
     <div className={styles.inner}>

--- a/src/stores/authStore.ts
+++ b/src/stores/authStore.ts
@@ -21,10 +21,10 @@ export interface SignInUser {
   };
 }
 
-// 로컬스토리지에서 사용자 정보 가져오기
+// 세션스토리지에서 사용자 정보 가져오기
 const getUserFromStorage = (): UserInfo | null => {
   try {
-    const userStr = localStorage.getItem('user');
+    const userStr = sessionStorage.getItem('user');
     return userStr ? JSON.parse(userStr) : null;
   } catch (error) {
     console.error('사용자 정보 파싱 실패:', error);
@@ -34,7 +34,7 @@ const getUserFromStorage = (): UserInfo | null => {
 
 // 앱 시작시 토큰 확인
 const checkInitialAuth = (): boolean => {
-  const token = localStorage.getItem('accessToken');
+  const token = sessionStorage.getItem('accessToken');
   return !!token;
 };
 
@@ -68,17 +68,17 @@ export const useAuthStore = create<AuthState>()(
       // 소셜 로그인
       setAuthSocialLogin: (data: SignInUser) => {
         const { accessToken, user } = data;
-        localStorage.setItem('accessToken', accessToken);
-        localStorage.setItem('user', JSON.stringify(user));
+        sessionStorage.setItem('accessToken', accessToken);
+        sessionStorage.setItem('user', JSON.stringify(user));
 
         set({ isLoggedIn: true, user: user });
       },
 
       // 로그인 상태로 설정 (개별 훅에서 호출)
       setLoggedIn: (user: UserInfo, accessToken: string) => {
-        // 로컬스토리지 저장
-        localStorage.setItem('accessToken', accessToken);
-        localStorage.setItem('user', JSON.stringify(user));
+        // 세션스토리지 저장
+        sessionStorage.setItem('accessToken', accessToken);
+        sessionStorage.setItem('user', JSON.stringify(user));
 
         // 상태 업데이트
         set({
@@ -89,9 +89,9 @@ export const useAuthStore = create<AuthState>()(
 
       // 로그아웃 상태로 설정 (개별 훅에서 호출)
       setLoggedOut: () => {
-        // 로컬스토리지 정리
-        localStorage.removeItem('accessToken');
-        localStorage.removeItem('user');
+        // 세션스토리지 정리
+        sessionStorage.removeItem('accessToken');
+        sessionStorage.removeItem('user');
 
         // 상태 업데이트
         set({
@@ -107,6 +107,20 @@ export const useAuthStore = create<AuthState>()(
         isLoggedIn: state.isLoggedIn,
         user: state.user,
       }),
+      // persist도 sessionStorage를 사용하도록 변경
+      storage: {
+        getItem: (name: string) => {
+          const value = sessionStorage.getItem(name);
+          return value ? JSON.parse(value) : null;
+        },
+        setItem: (name: string, value: unknown) => {
+          // any → unknown
+          sessionStorage.setItem(name, JSON.stringify(value));
+        },
+        removeItem: (name: string) => {
+          sessionStorage.removeItem(name);
+        },
+      },
     }
   )
 );

--- a/src/utils/authChatUtils.ts
+++ b/src/utils/authChatUtils.ts
@@ -1,7 +1,7 @@
 // 로그인된 사용자 정보 가져오기
 export const getCurrentUser = () => {
   try {
-    const userStr = localStorage.getItem('user');
+    const userStr = sessionStorage.getItem('user');
     if (userStr) {
       return JSON.parse(userStr);
     }

--- a/src/utils/isCurrentUserOwner.ts
+++ b/src/utils/isCurrentUserOwner.ts
@@ -7,7 +7,7 @@ type Member = {
 
 export function isCurrentUserOwner(data: Member[]): boolean {
   try {
-    const user = JSON.parse(localStorage.getItem('user') || '');
+    const user = JSON.parse(sessionStorage.getItem('user') || '');
     const currentUserId = user?.id;
     const owner = data.find(member => member.role === 'OWNER');
     return owner?.userId === currentUserId;


### PR DESCRIPTION
## 🔀 PR 제목
- [FE][Fix] login and token refactore 
---

## 📌 작업 내용 요약
- 로그인 폼의 이메일 저장하기 체크박스 섹션 제거
- 인증토큰 재발급 API 적용
- user 및 인증 토큰 세션 스토리지 사용으로 변경

---

## ✅ 체크리스트
PR을 올리기 전에 아래 항목을 확인했나요?

- [x] 기능 요구사항을 모두 구현했나요?
- [x] 로컬에서 기능을 직접 테스트했나요?
- [x] 코드 컨벤션 및 스타일을 지켰나요?
- [x] 관련된 이슈에 연결했나요?

---

## 🔗 관련 이슈
- Closes #194
---

## 📎 기타 참고 사항
- 일단 채팅창 쪽에서 사용하고 있는 `localStorage.getItem('accessToken')` 등의 코드를 `sessionStorage.getItem('accessToken')`로 고쳤으나 담당자분께서 기능에 오류가 없는지 확인 한번 부탁드립니다.
  - cc. @ebbll 
- 리프레시 토큰? 처음 써봐여.. 제대로 했는지 확인 한번만 부탁드립니다..!
  - cc. @projectmiluju 
