### PR TITLE
hotfix(ChatStompVer): 무한 로딩 로직 제거 및 최소 1초 로딩 화면 보장 / DP-206

### DIFF
--- a/src/features/Chat/ChatStompVer.tsx
+++ b/src/features/Chat/ChatStompVer.tsx
@@ -38,12 +38,20 @@ const Chat: React.FC<ChattingProps> = ({ isConnected, connectedCount, messages, 
   const [totalMessages, setTotalMessages] = useState<ChatReceivedMessage[]>([]);
   const prevMessagesRef = useRef<ChatReceivedMessage[]>([]);
   const [searchResults, setSearchResults] = useState<SearchMessagesData | null>(null);
+  const [showLoading, setShowLoading] = useState(true);
 
   // 현재 사용자 ID (메시지 비교용)
   const currentUserId = getCurrentUserId();
   // const { data, isSuccess } = useGetPreviousChat(repoId);
-  const { data, fetchNextPage, hasNextPage, isLoading, isSuccess } =
-    useGetChatMessagesInfinite(repoId);
+  const { data, fetchNextPage, hasNextPage, isSuccess } = useGetChatMessagesInfinite(repoId);
+
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      setShowLoading(false);
+    }, 1000);
+
+    return () => clearTimeout(timer);
+  }, []);
 
   // SearchMessageData 타입을 ChatReceivedMessage로 변환
   const searchMessages: ChatReceivedMessage[] = searchResults
@@ -168,7 +176,7 @@ const Chat: React.FC<ChattingProps> = ({ isConnected, connectedCount, messages, 
         <CurrentMembers onlineCount={connectedCount} />
 
         {/* 로딩 중일 때 로딩 컴포넌트 표시 */}
-        {!isConnected && !isLoading && <Loading />}
+        {(!isConnected || showLoading) && <Loading />}
 
         {/* 채팅 메시지 목록 */}
         <div className="chat__messages" onScroll={handleScroll}>


### PR DESCRIPTION
## 🔀 PR 제목
- [[FE][Fix] 채팅창 무한 로딩 문제 해결 


---

## 📌 작업 내용 요약
- 처음 Repo 페이지 접속 후 Chat 버튼 클릭시 무한 루프 렌더링 현상 해결

---

## ✅ 체크리스트
PR을 올리기 전에 아래 항목을 확인했나요?

- [x] 기능 요구사항을 모두 구현했나요?
- [x] 로컬에서 기능을 직접 테스트했나요?
- [x] 코드 컨벤션 및 스타일을 지켰나요?
- [x] 관련된 이슈에 연결했나요?

---

## 🔗 관련 이슈

- Closes #209

---


