### PR TITLE
[fix] 채팅 초기 데이터가 없을 때 무한로딩 제거

### DIFF
--- a/src/features/Chat/ChatStompVer.tsx
+++ b/src/features/Chat/ChatStompVer.tsx
@@ -42,7 +42,6 @@ const Chat: React.FC<ChattingProps> = ({ isConnected, connectedCount, messages, 
 
   // 현재 사용자 ID (메시지 비교용)
   const currentUserId = getCurrentUserId();
-  // const { data, isSuccess } = useGetPreviousChat(repoId);
   const { data, fetchNextPage, hasNextPage, isSuccess } = useGetChatMessagesInfinite(repoId);
 
   useEffect(() => {

--- a/src/features/Chat/ChatStompVer.tsx
+++ b/src/features/Chat/ChatStompVer.tsx
@@ -186,12 +186,6 @@ const Chat: React.FC<ChattingProps> = ({ isConnected, connectedCount, messages, 
             </div>
           )}
 
-          {displayMessages && displayMessages.length === 0 && (
-            <div style={{ padding: '10px', textAlign: 'center', color: '#999', fontSize: '12px' }}>
-              {searchResults ? '검색 결과가 없습니다.' : <Loading />}
-            </div>
-          )}
-
           {displayMessages.map((message, index) => {
             const shouldShowDate = shouldShowDateDivider(message, index);
             const isMyMessage = String(message.senderId) === currentUserId;


### PR DESCRIPTION
## 📌 작업 내용 요약

새로운 채팅방 초기 데이터 없을시 무한로딩 현상 해결

---

## ✅ 체크리스트
PR을 올리기 전에 아래 항목을 확인했나요?

- [x] 기능 요구사항을 모두 구현했나요?
- [x] 로컬에서 기능을 직접 테스트했나요?
- [x] 코드 컨벤션 및 스타일을 지켰나요?
- [x] 관련된 이슈에 연결했나요?

---

## 🔗 관련 이슈

- Closes #217 