### PR TITLE
[Fix] 좋아요 필터 시 리스트 페이지와 개수가 안 맞을 경우 에러 발생

### DIFF
--- a/src/pages/Main/PrivateRepoPage/PrivateRepoPage.tsx
+++ b/src/pages/Main/PrivateRepoPage/PrivateRepoPage.tsx
@@ -106,6 +106,7 @@ const PrivateRepoPage = () => {
   // 좋아요 필터
   const handleLikChange = () => {
     setIsLiked(!isLiked);
+    setPagination(prev => ({ ...prev, current: 1 }));
     repositoryRefetch();
   };
 

--- a/src/pages/Main/SharedByMeRepoPage/SharedByMeRepoPage.tsx
+++ b/src/pages/Main/SharedByMeRepoPage/SharedByMeRepoPage.tsx
@@ -88,6 +88,7 @@ const SharedByMeRepoPage = () => {
   // 좋아요 필터
   const handleLikChange = () => {
     setIsLiked(!isLiked);
+    setPagination(prev => ({ ...prev, current: 1 }));
     repositoryRefetch();
   };
 

--- a/src/pages/Main/SharedWithMeRepoPage/SharedWithMeRepoPage.tsx
+++ b/src/pages/Main/SharedWithMeRepoPage/SharedWithMeRepoPage.tsx
@@ -90,6 +90,7 @@ const SharedWithMeRepoPage = () => {
   // 좋아요 필터
   const handleLikChange = () => {
     setIsLiked(!isLiked);
+    setPagination(prev => ({ ...prev, current: 1 }));
     repositoryRefetch();
   };
 


### PR DESCRIPTION
## 🔀 PR 제목
[Fix] 좋아요 필터 시 리스트 페이지와 개수가 안 맞을 경우 에러 발생

---

## 📌 작업 내용 요약
좋아요 필터 변경 때 마다 1페이지로 초기화되도록 수정

---

## ✅ 체크리스트
PR을 올리기 전에 아래 항목을 확인했나요?

- [x] 기능 요구사항을 모두 구현했나요?
- [x] 로컬에서 기능을 직접 테스트했나요?
- [x] 코드 컨벤션 및 스타일을 지켰나요?
- [x] 관련된 이슈에 연결했나요?

---

## 🔗 관련 이슈
Closes #222

---

## 📎 기타 참고 사항

