### PR TITLE
[Refactor] 터미널 섹션 배경색 다크모드에 따라 변경

### DIFF
--- a/src/pages/Repo/RepoPage.module.scss
+++ b/src/pages/Repo/RepoPage.module.scss
@@ -150,7 +150,11 @@
   flex: 0 0 273px;
   box-sizing: border-box;
   overflow: hidden;
-  background-color: #343a40;
+  background-color: $gray-10;
+
+  &.darkMode {
+    background-color: $gray-2;
+  }
 
   @media screen and (height <= 700px) {
     flex: 0 0 200px;

--- a/src/pages/Repo/RepoPage.tsx
+++ b/src/pages/Repo/RepoPage.tsx
@@ -9,6 +9,7 @@ import { useCollaborationStore } from '@/stores/collaborationStore';
 import { useAuthStore } from '@/stores/authStore';
 import { useFileContentLoader } from '@/hooks/repo/useFileContentLoader';
 import { useYjsSavePoint } from '@/hooks/repo/useYjsSavePoint';
+import { useThemeStore } from '@/stores/themeStore';
 import Loading from '@/components/molecules/Loading/Loading';
 import styles from './RepoPage.module.scss';
 import TabBar from '@/components/organisms/TabBar/TabBar';
@@ -38,6 +39,7 @@ export function RepoPage() {
   const search = useSearch({ strict: false });
   const repoId = params.repoId;
   const filePath = search.file;
+  const { isDarkMode } = useThemeStore();
 
   const {
     openTabs,
@@ -358,7 +360,7 @@ export function RepoPage() {
           </div>
         </div>
 
-        <div className={styles.terminalSection}>
+        <div className={`${styles.terminalSection} ${isDarkMode ? styles.darkMode : ''}`}>
           <CodeRunner
             repoId={repoId}
             repositoryName={repositoryInfo?.repositoryName}


### PR DESCRIPTION
## 📌 작업 내용 요약
어떤 작업을 했는지 간략히 설명해주세요.

- 레포페이지에 다크모드 설정을 가져왔습니다.
- 모드에 맞게 터미널 영역 배경색이 적용됩니다.

---

## ✅ 체크리스트
PR을 올리기 전에 아래 항목을 확인했나요?

- [x] 기능 요구사항을 모두 구현했나요?
- [x] 로컬에서 기능을 직접 테스트했나요?
- [x] 코드 컨벤션 및 스타일을 지켰나요?
- [x] 관련된 이슈에 연결했나요?

---

## 🔗 관련 이슈

- Closes #229 

---

## 스크린샷
<img width="1623" height="1056" alt="image" src="https://github.com/user-attachments/assets/a674cfb6-b730-4bf8-b77e-b035827c6243" />
<img width="1623" height="1056" alt="image" src="https://github.com/user-attachments/assets/2d5024ec-4e0f-4e98-ad40-b922cc20342c" />
라이트모드일땐 밝구오 다크모드일땐 어두워요