### PR TITLE
[Refactor] 환경설정 내 Share섹션 내부 스타일링 조정

### DIFF
--- a/src/components/organisms/Settings/InfoSection/InfoSection.module.scss
+++ b/src/components/organisms/Settings/InfoSection/InfoSection.module.scss
@@ -74,6 +74,12 @@
         .icon {
           width: 20px;
           height: 20px;
+          cursor: pointer;
+
+          &:hover {
+            opacity: 1;
+            transform: scale(1.1);
+          }
         }
       }
     }

--- a/src/components/organisms/Settings/ShareSection/ShareSection.module.scss
+++ b/src/components/organisms/Settings/ShareSection/ShareSection.module.scss
@@ -89,7 +89,9 @@
   }
 
   .linkWrapper {
-    width: 424px;
+    display: flex;
+    flex-direction: row;
+    padding-right: 37px;
 
     @include mobile {
       width: 100%;
@@ -110,7 +112,7 @@
   .input {
     box-sizing: border-box;
     width: 100%;
-    max-width: 424px;
+    max-width: 350px;
     padding: 0.75rem 1rem;
     border: 1px solid $gray-8;
     border-radius: 6px;
@@ -177,10 +179,15 @@
   flex-direction: row;
   align-items: center;
   gap: 10px;
-  cursor: pointer;
 
   .icon {
     width: 20px;
     height: 20px;
+    cursor: pointer;
+
+    &:hover {
+      opacity: 1;
+      transform: scale(1.1);
+    }
   }
 }

--- a/src/components/organisms/Settings/ShareSection/ShareSection.tsx
+++ b/src/components/organisms/Settings/ShareSection/ShareSection.tsx
@@ -113,6 +113,7 @@ const ShareSection = ({ onShareLinkCopy }: shareSectionProps) => {
         <ShareIcon className={styles.nameIcon} />
         <h2 className={styles.sectionTitle}>SHARE</h2>
       </div>
+
       {/* 링크 공유 */}
       {settingsData.isShared && (
         <div className={`${styles.itemWrapper} ${styles.shareWrapper}`}>
@@ -127,14 +128,14 @@ const ShareSection = ({ onShareLinkCopy }: shareSectionProps) => {
                 <CopyIcon className={styles.icon} />
               </div>
             </div>
-
-            {/* 공유 링크 인풋 */}
-            {settingsData.shareLink && (
-              <input type="text" value={settingsData.shareLink} readOnly className={styles.input} />
-            )}
           </div>
+          {/* 공유 링크 인풋 */}
+          {settingsData.shareLink && (
+            <input type="text" value={settingsData.shareLink} readOnly className={styles.input} />
+          )}
         </div>
       )}
+
       {/* 입장 코드 */}
       {settingsData.isShared && isCurrentUserOwner(settingsData.members) && (
         <div className={`${styles.itemWrapper} ${styles.entryCodeWrapper}`}>


### PR DESCRIPTION
## 📌 작업 내용 요약

- 스타일링 수정

---

## ✅ 체크리스트
PR을 올리기 전에 아래 항목을 확인했나요?

- [x] 기능 요구사항을 모두 구현했나요?
- [x] 로컬에서 기능을 직접 테스트했나요?
- [x] 코드 컨벤션 및 스타일을 지켰나요?
- [x] 관련된 이슈에 연결했나요?

---

## 🔗 관련 이슈

- Closes #231 

---

## 📎 기타 참고 사항
<img width="575" height="280" alt="image" src="https://github.com/user-attachments/assets/880bef25-5724-43d3-a845-775b7ebd2b4e" />
내부에서 간격 서로 안 맞는 부분 있어서 수정했습니다 아이콘들도 호버 효과가 서로 달라서 통일했습니다
